### PR TITLE
This was triggering when parentGroup.iterationTime == 0, which was causi...

### DIFF
--- a/web-animation.js
+++ b/web-animation.js
@@ -336,7 +336,7 @@ mixin(TimedItem.prototype, {
       this.endTime = this._startTime + this.animationDuration +
           this.timing.startDelay + this.timeDrift;
     }
-    if (this.parentGroup && this.parentGroup.iterationTime) {
+    if (this.parentGroup && (this.parentGroup.iterationTime !== null)) {
       this.itemTime = this.parentGroup.iterationTime -
           this._startTime - this.timeDrift;
     } else if (isDefined(parentTime)) {


### PR DESCRIPTION
...ng forward fill of reversed animations to fail (test-start-time.html and test-start-time-tierations.html picked this up).
