### PR TITLE
Fix style in tests

### DIFF
--- a/demo_example.html
+++ b/demo_example.html
@@ -122,8 +122,7 @@ function first() {
 }
 
 function second() {
-  new Animation(document.querySelector("circle"),
-    { cx: '400px' }, 3);
+  new Animation(document.querySelector("circle"), { cx: '400px' }, 3);
 }
 
 // STEP 2
@@ -147,8 +146,7 @@ var pictureTilting = undefined;
 
 function fifth() {
   var picture = document.querySelector(".picture");
-  pictureTilting =
-    new Animation(picture,
+  pictureTilting = new Animation(picture,
       { '-webkit-transform': [ 'rotate(0deg)', 'rotate(-30deg)' ] }, 0.5);
   group = new SeqGroup([a, pictureTilting]);
   console.log(window.document.animationTimeline.currentState());
@@ -175,7 +173,7 @@ function audioAnimFunction() {
 
 function seventh() {
   var doorCreakAnim =
-    new Animation(null, new audioAnimFunction("CREEEEEEAAAAKKK"), 2);
+      new Animation(null, new audioAnimFunction("CREEEEEEAAAAKKK"), 2);
   var closeAnim = new ParGroup([ a, doorCreakAnim ]);
   closeAnim.timing.timingFunc = a.timing.timingFunc;
   a.timing.timingFunc = null;

--- a/test-calc.html
+++ b/test-calc.html
@@ -84,25 +84,27 @@ limitations under the License.
 
 </style>
 
-Blue lines should all hit the deep red boundary at the same time, then completely cover the light red box when the animation has finished.
+Blue lines should all hit the deep red boundary at the same time, then
+completely cover the light red box when the animation has finished.
 
 <div class="outer">
-<div class="expectation2"></div>
-<div class="expectation" style="top: 0px; width: 150px"></div>
-<div class="anim" id="a"></div>
-<div class="expectation" style="top: 50px; width: 187.5px"></div>
-<div class="anim" id="b"></div>
-<div class="expectation" style="top: 100px; width: 225px"></div>
-<div class="anim" id="c"></div>
-<div class="expectation" style="top: 150px; width: 168.75px"></div>
-<div class="anim" id="d"></div>
-<div class="expectation" style="top: 200px; width: 168.75px"></div>
-<div class="anim" id="e"></div>
-<div class="expectation" style="top: 250px; width: 218.75px"></div>
-<div class="anim" id="f"></div>
-<div class="expectation" style="top: 300px; width: 131.25px"></div>
-<div class="anim" id="g"></div>
+  <div class="expectation2"></div>
+  <div class="expectation" style="top: 0px; width: 150px"></div>
+  <div class="anim" id="a"></div>
+  <div class="expectation" style="top: 50px; width: 187.5px"></div>
+  <div class="anim" id="b"></div>
+  <div class="expectation" style="top: 100px; width: 225px"></div>
+  <div class="anim" id="c"></div>
+  <div class="expectation" style="top: 150px; width: 168.75px"></div>
+  <div class="anim" id="d"></div>
+  <div class="expectation" style="top: 200px; width: 168.75px"></div>
+  <div class="anim" id="e"></div>
+  <div class="expectation" style="top: 250px; width: 218.75px"></div>
+  <div class="anim" id="f"></div>
+  <div class="expectation" style="top: 300px; width: 131.25px"></div>
+  <div class="anim" id="g"></div>
 </div>
+
 <script src="web-animation.js"></script>
 <script>
 
@@ -117,10 +119,13 @@ new Animation(document.querySelector("#c"), {width: "400px"}, 2);
 // 25px -> 0px linear, 12.5% -> 50% (25px -> 400px quadratic)
 new Animation(document.querySelector("#d"), {width: "50%"}, 2);
 // 50px -> 100px linear, 0% -> 37.5% (0px -> 300px quadratic)
-new Animation(document.querySelector("#e"), {width: "-webkit-calc(37.5% + 100px)"}, 2);
+new Animation(document.querySelector("#e"),
+    {width: "-webkit-calc(37.5% + 100px)"}, 2);
 // 0px -> 100px linear, 25% -> 37.5% (50px -> 300px quadratic)
-new Animation(document.querySelector("#f"), {width: "-webkit-calc(37.5% + 100px)"}, 2);
+new Animation(document.querySelector("#f"),
+    {width: "-webkit-calc(37.5% + 100px)"}, 2);
 // 100px -> 100px linear, -25% -> 37.5% (-50px -> 300px quadratic)
-new Animation(document.querySelector("#g"), {width: "-webkit-calc(37.5% + 100px)"}, 2);
+new Animation(document.querySelector("#g"),
+    {width: "-webkit-calc(37.5% + 100px)"}, 2);
 
 </script>

--- a/test-change-playback-rate.html
+++ b/test-change-playback-rate.html
@@ -41,9 +41,9 @@ var a1 = new Animation(document.querySelector("#a"),
 
 var a2 = new Animation(undefined,
     {sample: function(timeFraction, iteration, target) {
-        a1.changePlaybackRate(0.01 + 10 * timeFraction);
-        a2.changePlaybackRate(0.01 + 10 * timeFraction);
-        document.querySelector("#a").innerText = a1.timing.playbackRate;
+      a1.changePlaybackRate(0.01 + 10 * timeFraction);
+      a2.changePlaybackRate(0.01 + 10 * timeFraction);
+      document.querySelector("#a").innerText = a1.timing.playbackRate;
     }},
     a1.timing.clone());
 </script>

--- a/test-color.html
+++ b/test-color.html
@@ -59,9 +59,14 @@ All three boxes should end up the same color as the outline.
 <script src="web-animation.js"></script>
 <script>
 
-new Animation(document.querySelector("#a"), {"background-color": ["red", "green"]}, 2);
-new Animation(document.querySelector("#b"), {"background-color": "rgb(0, 128, 0)"}, 2);
-new Animation(document.querySelector("#c"), {"background-color": [{offset: 0.25, value: "rgb(255, 0, 0)"}, {offset: 0.75, value: "rgb(0, 0, 255)"}], operation: "add"}, 2);
+new Animation(document.querySelector("#a"),
+    {"background-color": ["red", "green"]}, 2);
+new Animation(document.querySelector("#b"), 
+    {"background-color": "rgb(0, 128, 0)"}, 2);
+new Animation(document.querySelector("#c"), {"background-color": [
+  {offset: 0.25, value: "rgb(255, 0, 0)"},
+  {offset: 0.75, value: "rgb(0, 0, 255)"}
+], operation: "add"}, 2);
 
 
 </script>

--- a/test-composite-transforms.html
+++ b/test-composite-transforms.html
@@ -17,52 +17,64 @@ limitations under the License.
 <!DOCTYPE html>
 <style>
 .anim {
-	left: 0px;
-	width: 100px;
-	height: 100px;
-	background-color: #FAA;
-	position: absolute;
+  left: 0px;
+  width: 100px;
+  height: 100px;
+  background-color: #FAA;
+  position: absolute;
 }
 
 .expected {
-	width: 100px;
-	height: 100px;
-	position: absolute;
-	border-right: 1px solid black;
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  border-right: 1px solid black;
 }
 
 #a {
-	top: 50px
+  top: 50px
 }
 
 #b {
-	top: 150px;
+  top: 150px;
 }
 
 #c {
-	top: 250px;
+  top: 250px;
 }
 
 #d {
-	top: 350px;
+  top: 350px;
 }
 
 </style>
 
 <div>Right edge of each box should align with black line at end of test.</div>
-<div id="a" class="anim"></div> <div id="a" style="top: 50px; left: 200px;" class="expected"></div>
-<div id="b" class="anim"></div> <div id="b" style="top: 150px; left: 0px;" class="expected"></div>
-<div id="c" class="anim"></div> <div id="c" style="top: 250px; left: 200px;" class="expected"></div>
-<div id="d" class="anim"></div> <div id="d" style="top: 550px; left: 0px;" class="expected"></div>
+<div id="a" class="anim"></div>
+<div id="a" style="top: 50px; left: 200px;" class="expected"></div>
+<div id="b" class="anim"></div>
+<div id="b" style="top: 150px; left: 0px;" class="expected"></div>
+<div id="c" class="anim"></div>
+<div id="c" style="top: 250px; left: 200px;" class="expected"></div>
+<div id="d" class="anim"></div>
+<div id="d" style="top: 550px; left: 0px;" class="expected"></div>
 
 <script src="web-animation.js"></script>
 <script>
 
 var divs = document.querySelectorAll(".anim");
 
-new Animation(divs[0], {"-webkit-transform": ["translate(0px, 0px)", "translate(200px, 0px)"]}, 2);
-new Animation(divs[1], {"-webkit-transform": ["rotate(0deg)", "rotate(90deg)"]}, 2);
-new Animation(divs[2], {"-webkit-transform": ["translate(0px, 0px) rotate(0deg)", "translate(200px, 0px) rotate(90deg)"]}, 2);
-new Animation(divs[3], {"-webkit-transform": ["rotate(0deg) translate(0px, 0px)", "rotate(90deg) translate(200px, 0px)"]}, 2);
+new Animation(divs[0],
+    {"-webkit-transform": ["translate(0px, 0px)", "translate(200px, 0px)"]}, 2);
+new Animation(divs[1],
+    {"-webkit-transform": ["rotate(0deg)", "rotate(90deg)"]}, 2);
+new Animation(divs[2], {"-webkit-transform": [
+  "translate(0px, 0px) rotate(0deg)",
+  "translate(200px, 0px) rotate(90deg)"
+]}, 2);
+new Animation(divs[3], {"-webkit-transform": [
+  "rotate(0deg) translate(0px, 0px)",
+  "rotate(90deg) translate(200px, 0px)"
+]}, 2);
 
 </script>

--- a/test-compositor.html
+++ b/test-compositor.html
@@ -25,10 +25,12 @@ limitations under the License.
 }
 </style>
 <svg>
-     <rect class="expectation" x="200px" y="10px" width="100px" height="100px"></rect>
-	<rect class="expectation" x="200px" y="20px" width="200px" height="200px"></rect>
-	<rect class="anim" x="100px" y="10px" width="100px" height="100px"></rect>
-     <rect class="anim2" x="100px" y="10px" width="100px" height="100px"></rect>
+  <rect class="expectation" x="200px" y="10px" width="100px" height="100px">
+  </rect>
+  <rect class="expectation" x="200px" y="20px" width="200px" height="200px">
+  </rect>
+  <rect class="anim" x="100px" y="10px" width="100px" height="100px"></rect>
+  <rect class="anim2" x="100px" y="10px" width="100px" height="100px"></rect>
 </svg>
 <script src="web-animation.js"></script>
 <script>
@@ -36,12 +38,24 @@ var rect = document.querySelector(".anim")
 var rect2 = document.querySelector(".anim2")
 
 new Animation(rect, {x: ["0px", "400px"]}, 3);
-new Animation(rect, {x: ["0px", "200px"], operation: 'add'}, {startDelay: 1, duration: 4});
-new Animation(rect, {x: ["0px", "200px"], operation: 'merge'}, {startDelay: 2, duration: 5});
+new Animation(rect, {x: ["0px", "200px"], operation: 'add'},
+    {startDelay: 1, duration: 4});
+new Animation(rect, {x: ["0px", "200px"], operation: 'merge'},
+    {startDelay: 2, duration: 5});
 
-new Animation(rect2, {"-webkit-transform": ["translate(0px, 0px)", "translate(200px, 200px)"]}, 3);
-new Animation(rect2, {"-webkit-transform": ["rotate(0deg) translate(0px, 0px)", 
-                                       "rotate(90deg) translate(100px, 0px)"], operation: 'add'}, {startDelay: 1, duration: 4});
-new Animation(rect2, {"-webkit-transform": ["translate(0px, 0px) rotate(0deg) translate(0px, 0px) scale(1, 1)", 
-                                       "translate(0px, 0px) rotate(0deg) translate(0px, 0px) scale(2, 2)"], operation: 'merge'}, {startDelay: 2, duration: 5});
+new Animation(rect2,
+    {"-webkit-transform": ["translate(0px, 0px)", "translate(200px, 200px)"]},
+    3);
+new Animation(rect2,
+    {"-webkit-transform": [
+      "rotate(0deg) translate(0px, 0px)", 
+      "rotate(90deg) translate(100px, 0px)"
+    ], operation: 'add'},
+    {startDelay: 1, duration: 4});
+new Animation(rect2,
+    {"-webkit-transform": [
+      "translate(0px, 0px) rotate(0deg) translate(0px, 0px) scale(1, 1)", 
+      "translate(0px, 0px) rotate(0deg) translate(0px, 0px) scale(2, 2)"
+    ], operation: 'merge'},
+    {startDelay: 2, duration: 5});
 </script>

--- a/test-fill-values.html
+++ b/test-fill-values.html
@@ -30,7 +30,7 @@ limitations under the License.
   position: relative;
 }
 
-.expected {
+.exp {
   border-right: 1px solid black;
 }
 
@@ -56,47 +56,47 @@ limitations under the License.
 <div>Right edge of each box should align with black line at end of test.</div>
 
 <div class="animContainer" id="ca">
-  <div style="width: 300px;" class="expected"><div id="a" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="b" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="c" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="d" class="anim"></div></div>
-  <div style="width: 500px;" class="expected"><div id="e" class="anim"></div></div>
-  <div style="width: 500px;" class="expected"><div id="f" class="anim"></div></div>
-  <div style="width: 500px;" class="expected"><div id="g" class="anim"></div></div>
-  <div style="width: 500px;" class="expected"><div id="h" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="a" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="b" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="c" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="d" class="anim"></div></div>
+  <div style="width: 500px;" class="exp"><div id="e" class="anim"></div></div>
+  <div style="width: 500px;" class="exp"><div id="f" class="anim"></div></div>
+  <div style="width: 500px;" class="exp"><div id="g" class="anim"></div></div>
+  <div style="width: 500px;" class="exp"><div id="h" class="anim"></div></div>
 </div>
 
 <div class="animContainer" id="cb">
-  <div style="width: 300px;" class="expected"><div id="a" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="b" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="c" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="d" class="anim"></div></div>
-  <div style="width: 400px;" class="expected"><div id="e" class="anim"></div></div>
-  <div style="width: 400px;" class="expected"><div id="f" class="anim"></div></div>
-  <div style="width: 400px;" class="expected"><div id="g" class="anim"></div></div>
-  <div style="width: 400px;" class="expected"><div id="h" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="a" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="b" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="c" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="d" class="anim"></div></div>
+  <div style="width: 400px;" class="exp"><div id="e" class="anim"></div></div>
+  <div style="width: 400px;" class="exp"><div id="f" class="anim"></div></div>
+  <div style="width: 400px;" class="exp"><div id="g" class="anim"></div></div>
+  <div style="width: 400px;" class="exp"><div id="h" class="anim"></div></div>
 </div>
 
 <div class="animContainer" id="cc">
-  <div style="width: 300px;" class="expected"><div id="a" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="b" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="c" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="d" class="anim"></div></div>
-  <div style="width: 400px;" class="expected"><div id="e" class="anim"></div></div>
-  <div style="width: 400px;" class="expected"><div id="f" class="anim"></div></div>
-  <div style="width: 400px;" class="expected"><div id="g" class="anim"></div></div>
-  <div style="width: 400px;" class="expected"><div id="h" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="a" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="b" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="c" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="d" class="anim"></div></div>
+  <div style="width: 400px;" class="exp"><div id="e" class="anim"></div></div>
+  <div style="width: 400px;" class="exp"><div id="f" class="anim"></div></div>
+  <div style="width: 400px;" class="exp"><div id="g" class="anim"></div></div>
+  <div style="width: 400px;" class="exp"><div id="h" class="anim"></div></div>
 </div>
 
 <div class="animContainer" id="cd">
-  <div style="width: 300px;" class="expected"><div id="a" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="b" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="c" class="anim"></div></div>
-  <div style="width: 300px;" class="expected"><div id="d" class="anim"></div></div>
-  <div style="width: 500px;" class="expected"><div id="e" class="anim"></div></div>
-  <div style="width: 500px;" class="expected"><div id="f" class="anim"></div></div>
-  <div style="width: 500px;" class="expected"><div id="g" class="anim"></div></div>
-  <div style="width: 500px;" class="expected"><div id="h" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="a" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="b" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="c" class="anim"></div></div>
+  <div style="width: 300px;" class="exp"><div id="d" class="anim"></div></div>
+  <div style="width: 500px;" class="exp"><div id="e" class="anim"></div></div>
+  <div style="width: 500px;" class="exp"><div id="f" class="anim"></div></div>
+  <div style="width: 500px;" class="exp"><div id="g" class="anim"></div></div>
+  <div style="width: 500px;" class="exp"><div id="h" class="anim"></div></div>
 </div>
 
 <script src="web-animation.js"></script>
@@ -107,12 +107,25 @@ var directions = ["normal", "reverse", "alternate", "alternate-reverse"];
 var fills = ["none", "backwards", "forwards", "both"];
 
 for (var i = 0; i < containers.length; i++) {
-  var divs = document.getElementById(containers[i]).getElementsByClassName('anim');
+  var divs =
+      document.getElementById(containers[i]).getElementsByClassName('anim');
   for (var j = 0; j < fills.length; j++) {
-    new Animation(divs[2 * j], {left: ["100px", "200px"]}, {iterationCount: 4, direction: directions[i], duration: 1, fillMode: fills[j]}, undefined, 1);
-    divs[2 * j].innerHTML = "dir: " + directions[i] + " fill: " + fills[j] + " dur: 1";
-    new Animation(divs[2 * j + 1], {left: ["100px", "200px"]}, {iterationCount: 4, direction: directions[i], duration: 0, fillMode: fills[j]}, undefined, 1);
-    divs[2 * j + 1].innerHTML = "dir: " + directions[i] + " fill: " + fills[j] + " dur: 0";
+    new Animation(divs[2 * j], {left: ["100px", "200px"]}, {
+      iterationCount: 4,
+      direction: directions[i],
+      duration: 1,
+      fillMode: fills[j]
+    }, undefined, 1);
+    divs[2 * j].innerHTML = "dir: " + directions[i] + " fill: " + fills[j] +
+        " dur: 1";
+    new Animation(divs[2 * j + 1], {left: ["100px", "200px"]}, {
+      iterationCount: 4,
+      direction: directions[i],
+      duration: 0,
+      fillMode: fills[j]
+    }, undefined, 1);
+    divs[2 * j + 1].innerHTML = "dir: " + directions[i] + " fill: " + fills[j] +
+        " dur: 0";
   }
 }
 

--- a/test-grouped-anim-func.html
+++ b/test-grouped-anim-func.html
@@ -24,13 +24,16 @@ limitations under the License.
 }
 </style>
 <svg>
-	<rect class="expectation" x="400px" y="200px" width="50px" height="100px"></rect>
-	<rect class="anim" x="100px" y="10px" width="100px" height="100px"></rect>
+  <rect class="expectation" x="400px" y="200px" width="50px" height="100px">
+  </rect>
+  <rect class="anim" x="100px" y="10px" width="100px" height="100px">
+  </rect>
 </svg>
 <script src="web-animation.js"></script>
 <script>
-var rect = document.querySelector(".anim")
+var rect = document.querySelector(".anim");
 
-var a = new Animation(rect, {x: "400px", y: ["300px", "200px"], width: ["100px", "20px", "50px"]}, 1);
+new Animation(rect,
+    {x: "400px", y: ["300px", "200px"], width: ["100px", "20px", "50px"]}, 1);
 
 </script>

--- a/test-harness.html
+++ b/test-harness.html
@@ -55,10 +55,10 @@ iframe {
   height: 600px;
 }
 </style>
-<button id=prev-button onclick="updateState(-1)">Prev</button>
-<button id=reload-button onclick="updateState()">Reload</button>
-<button id=next-button onclick="updateState(1)">Next</button><br>
-<span id=test-num></span><a id=test-name></a><br>
+<button id="prev-button" onclick="updateState(-1)">Prev</button>
+<button id="reload-button" onclick="updateState()">Reload</button>
+<button id="next-button" onclick="updateState(1)">Next</button><br>
+<span id="test-num"></span><a id="test-name"></a><br>
 <iframe></iframe>
 <script>
 var currentTest = 0;
@@ -72,12 +72,14 @@ function updateState(change) {
   }
   var test = tests[currentTest];
   window.location.hash = test;
-  document.querySelector('#test-num').innerText = (currentTest + 1) + ' of ' + tests.length + ': ';
+  document.querySelector('#test-num').innerText =
+      (currentTest + 1) + ' of ' + tests.length + ': ';
   document.querySelector('#test-name').innerText = test;
   document.querySelector('#test-name').href = test;
   document.querySelector('iframe').src = test;
   document.querySelector('#prev-button').disabled = currentTest <= 0;
-  document.querySelector('#next-button').disabled = currentTest >= tests.length - 1;
+  document.querySelector('#next-button').disabled =
+      currentTest >= tests.length - 1;
 }
 
 updateState();

--- a/test-integer.html
+++ b/test-integer.html
@@ -26,7 +26,7 @@ position:absolute;
 }
 </style>
 <body>
-<div id=test></div>
+<div id="test"></div>
 <script src="web-animation.js"></script>
 <script>
 var width = 25;
@@ -34,13 +34,15 @@ var totalWidth = 800;
 var startZ = 0;
 var endZ = 100;
 for (var i = 0; i < totalWidth; i += width) {
-  var div = document.createElement('div');
-  div.style.width = width + 'px';
-  div.style.height = '50px';
-  div.style.background = 'red';
-  div.style['z-index'] = startZ + Math.round((i / totalWidth) * (endZ - startZ));
-  div.style.position = 'relative';
+  var div = document.createElement("div");
+  div.style.width = width + "px";
+  div.style.height = "50px";
+  div.style.background = "red";
+  div.style["z-index"] = startZ +
+      Math.round((i / totalWidth) * (endZ - startZ));
+  div.style.position = "relative";
   document.body.appendChild(div);
 }
-var anim = new Animation(document.querySelector('#test'), {'z-index': [String(startZ), String(endZ)]}, 3);
+new Animation(document.querySelector("#test"),
+    {"z-index": [String(startZ), String(endZ)]}, 3);
 </script>

--- a/test-iteration-start.html
+++ b/test-iteration-start.html
@@ -53,17 +53,19 @@ limitations under the License.
 .expectation {
   position: absolute;
   background-color: red;
+  width: 100px;
 }
 </style>
 
-<div>All squares should line up at the end of each iteration (or start if reversed).</div>
+<div>All squares should line up at the end of each iteration (or start if
+reversed).</div>
 
-<div class="expectation" style="top: 50px; left: 180px; width: 100px; height: 25px;"></div>
-<div class="expectation" style="top: 100px; left: 180px; width: 100px; height: 100px;"></div>
-<div class="expectation" style="top: 250px; left: 0px; width: 100px; height: 150px;"></div>
-<div class="expectation" style="top: 450px; left: 0px; width: 100px; height: 150px;"></div>
-<div class="expectation" style="top: 650px; left: 180px; width: 100px; height: 25px;"></div>
-<div class="expectation" style="top: 700px; left: 180px; width: 100px; height: 100px;"></div>
+<div class="expectation" style="top: 50px; left: 180px; height: 25px;"></div>
+<div class="expectation" style="top: 100px; left: 180px; height: 100px;"></div>
+<div class="expectation" style="top: 250px; left: 0px; height: 150px;"></div>
+<div class="expectation" style="top: 450px; left: 0px; height: 150px;"></div>
+<div class="expectation" style="top: 650px; left: 180px; height: 25px;"></div>
+<div class="expectation" style="top: 700px; left: 180px; height: 100px;"></div>
 
 <div class="animContainer" id="ca">
   <div class="anim a"></div>
@@ -111,32 +113,53 @@ var groups = [];
 
 for (var i = 0; i < directions.length; i++) {
   var dir = directions[i];
-  var group = new ParGroup([], {iterationCount: 2, direction: dir, duration: 4}, undefined, 1);
+  var group = new ParGroup([], {iterationCount: 2, direction: dir, duration: 4},
+      undefined, 1);
   groups.push(group);
 }
 
 for (var i = 0; i < containers.length; i++) {
   var container = document.getElementById(containers[i]);
   // Test basic use.
-  new Animation(container.getElementsByClassName("a")[0], {left: ["100px", "300px"]}, {duration: 1, iterationCount: 3.1, iterationStart: 0.3}, groups[i]);
+  new Animation(container.getElementsByClassName("a")[0],
+      {left: ["100px", "300px"]},
+      {duration: 1, iterationCount: 3.1, iterationStart: 0.3},
+      groups[i]);
   try {
     // Test that iterationStart has a lower bound of zero.
-    new Animation(container.getElementsByClassName("b")[0], {left: ["100px", "300px"]}, {duration: 1, iterationCount: 3.4, iterationStart: -0.2}, groups[i]);
+    new Animation(container.getElementsByClassName("b")[0],
+        {left: ["100px", "300px"]},
+        {duration: 1, iterationCount: 3.4, iterationStart: -0.2}, groups[i]);
   } catch (e) {
     if (e.name == "IndexSizeError") {
-      container.getElementsByClassName("b")[0].style["background-color"] = "lightsteelblue";
+      container.getElementsByClassName("b")[0].style["background-color"] =
+          "lightsteelblue";
       if (i == 0 || i == 3) {
         container.getElementsByClassName("b")[0].style["left"] = "180px";
       }
     }
   }    
   // Test that iterationStart is not clipped to iterationCount.
-  new Animation(container.getElementsByClassName("c")[0], {left: ["100px", "300px"]}, {duration: 1, iterationCount: 1.6, iterationStart: 1.8}, groups[i]);
+  new Animation(container.getElementsByClassName("c")[0],
+      {left: ["100px", "300px"]},
+      {duration: 1, iterationCount: 1.6, iterationStart: 1.8},
+      groups[i]);
   // Test that nothing odd happens when iterationCount is an integer.
-  new Animation(container.getElementsByClassName("d")[0], {left: ["100px", "300px"]}, {duration: 1, iterationCount: 3.0, iterationStart: 0.4}, groups[i]);
-  // Test that nothing odd happens when (iterationCount - iterationStart) is an integer.
-  new Animation(container.getElementsByClassName("e")[0], {left: ["100px", "300px"]}, {duration: 1, iterationCount: 3.2, iterationStart: 0.2}, groups[i]);
-  // Test that nothing odd happens when (iterationCount + iterationStart) is an integer.
-  new Animation(container.getElementsByClassName("f")[0], {left: ["100px", "180px"]}, {duration: 1, iterationCount: 2.8, iterationStart: 0.2}, groups[i]);
+  new Animation(container.getElementsByClassName("d")[0],
+      {left: ["100px", "300px"]},
+      {duration: 1, iterationCount: 3.0, iterationStart: 0.4},
+      groups[i]);
+  // Test that nothing odd happens when (iterationCount - iterationStart) is an
+  // integer.
+  new Animation(container.getElementsByClassName("e")[0],
+      {left: ["100px", "300px"]},
+      {duration: 1, iterationCount: 3.2, iterationStart: 0.2},
+      groups[i]);
+  // Test that nothing odd happens when (iterationCount + iterationStart) is an
+  // integer.
+  new Animation(container.getElementsByClassName("f")[0],
+      {left: ["100px", "180px"]},
+      {duration: 1, iterationCount: 2.8, iterationStart: 0.2},
+      groups[i]);
 }
 </script>

--- a/test-iterations-basic.html
+++ b/test-iterations-basic.html
@@ -53,7 +53,8 @@ limitations under the License.
 }
 </style>
 
-<div>Boxes in each group should line up with each other at end of each iteration (or start if reversed).</div>
+<div>Boxes in each group should line up with each other at end of each
+iteration (or start if reversed).</div>
 <div>Right edge of each box should align with black line at end of test.</div>
 
 <div class="animContainer" id="ca">
@@ -90,17 +91,24 @@ var groups = [];
 
 for (var i = 0; i < directions.length; i++) {
   var dir = directions[i];
-  var group = new ParGroup([], {iterationCount: 2, direction: dir, duration: 4}, undefined, 1);
+  var group = new ParGroup([], {iterationCount: 2, direction: dir, duration: 4},
+      undefined, 1);
   groups.push(group);
 }
 
 for (var i = 0; i < containers.length; i++) {
   var container = document.getElementById(containers[i]);
   // Test basic use.
-  new Animation(container.getElementsByClassName("a")[0], {left: ["100px", "300px"]}, {duration: 1, iterationCount: 3.4}, groups[i]);
+  new Animation(container.getElementsByClassName("a")[0],
+      {left: ["100px", "300px"]}, {duration: 1, iterationCount: 3.4},
+      groups[i]);
   // Test integer iterationCount.
-  new Animation(container.getElementsByClassName("b")[0], {left: ["100px", "180px"]}, {duration: 1, iterationCount: 3.0}, groups[i]);
+  new Animation(container.getElementsByClassName("b")[0],
+      {left: ["100px", "180px"]}, {duration: 1, iterationCount: 3.0},
+      groups[i]);
   // Test zero iterationCount.
-  new Animation(container.getElementsByClassName("c")[0], {left: ["180px", "300px"]}, {duration: 1, iterationCount: 0.0}, groups[i]);
+  new Animation(container.getElementsByClassName("c")[0],
+      {left: ["180px", "300px"]}, {duration: 1, iterationCount: 0.0},
+      groups[i]);
 }
 </script>

--- a/test-iterations-fill.html
+++ b/test-iterations-fill.html
@@ -109,19 +109,37 @@ var groups = [];
 
 for (var i = 0; i < directions.length; i++) {
   var dir = directions[i];
-  var group = new ParGroup([], {startDelay: 1, duration: 8, iterationCount: 3, playbackRate: 2, direction: dir}, undefined, 1);
+  var group = new ParGroup([], {
+    startDelay: 1,
+    duration: 8,
+    iterationCount: 3,
+    playbackRate: 2,
+    direction: dir
+  }, undefined, 1);
   groups.push(group);
 }
 
 function sampleFunc(timeFraction, iteration, target) {
-  target.innerHTML = Math.floor(timeFraction * 1000) / 1000 + " : " + iteration
+  target.innerHTML = Math.floor(timeFraction * 1000) / 1000 + " : " + iteration;
 }
 
 for (var i = 0; i < fillModes.length; i++) {
   var divs = document.querySelectorAll(categories[i]);
   for (var j = 0; j < divs.length; j++) {
-    new Animation(divs[j], {left: ["100px", "200px"]}, {startDelay: 1, duration: 1, iterationCount: 2, fillMode: fillModes[i], playbackRate: 0.8}, groups[j], 1);
-    new Animation(divs[j], {sample: sampleFunc}, {startDelay: 1, duration: 1, iterationCount: 2, fillMode: fillModes[i], playbackRate: 0.8}, groups[j], 1);
-	}
+    new Animation(divs[j], {left: ["100px", "200px"]}, {
+      startDelay: 1,
+      duration: 1,
+      iterationCount: 2,
+      fillMode: fillModes[i],
+      playbackRate: 0.8
+    }, groups[j], 1);
+    new Animation(divs[j], {sample: sampleFunc}, {
+      startDelay: 1,
+      duration: 1,
+      iterationCount: 2,
+      fillMode: fillModes[i],
+      playbackRate: 0.8
+    }, groups[j], 1);
+  }
 }
 </script>

--- a/test-keyframe-creation.html
+++ b/test-keyframe-creation.html
@@ -17,40 +17,40 @@ limitations under the License.
 <!DOCTYPE html>
 <style>
 .anim {
-	left: 50px;
-	width: 100px;
-	height: 100px;
-	background-color: lightsteelblue;
-	position: absolute;
+  left: 50px;
+  width: 100px;
+  height: 100px;
+  background-color: lightsteelblue;
+  position: absolute;
 }
 
 #a {
-	top: 0px
+  top: 0px
 }
 
 #b {
-	top: 100px;
+  top: 100px;
 }
 
 #c {
-	top: 200px
+  top: 200px
 }
 
 #d {
-	top: 300px;
+  top: 300px;
 }
 
 #e {
-        top: 400px;
+  top: 400px;
 }
 
 #f {
-        top: 500px;
+  top: 500px;
 }
 
 #g {
-        top: 600px;
-        left: 200px;
+  top: 600px;
+  left: 200px;
 }
 
 #expectation {
@@ -66,25 +66,39 @@ limitations under the License.
 <div id=expectation></div>
 
 <div>
-	<div id="a" class="anim"></div>
-	<div id="b" class="anim"></div>
-	<div id="c" class="anim"></div>
-	<div id="d" class="anim"></div>
-	<div id="e" class="anim"></div>
-	<div id="f" class="anim"></div>
-	<div id="g" class="anim"></div>
+  <div id="a" class="anim"></div>
+  <div id="b" class="anim"></div>
+  <div id="c" class="anim"></div>
+  <div id="d" class="anim"></div>
+  <div id="e" class="anim"></div>
+  <div id="f" class="anim"></div>
+  <div id="g" class="anim"></div>
 </div>
 
 <script src="web-animation.js"></script>
 <script>
 
-new Animation(document.querySelector("#a"), {left: ["100px", "200px"]}, {startDelay: 1, duration: 1});
-new Animation(document.querySelector("#b"), {left: "200px"}, {startDelay: 1, duration: 1});
-new Animation(document.querySelector("#c"), {left: ["100px", "200px"]}, {duration: 2});
+new Animation(document.querySelector("#a"), {left: ["100px", "200px"]},
+    {startDelay: 1, duration: 1});
+new Animation(document.querySelector("#b"), {left: "200px"},
+    {startDelay: 1, duration: 1});
+new Animation(document.querySelector("#c"), {left: ["100px", "200px"]},
+    {duration: 2});
 new Animation(document.querySelector("#d"), {left: "200px"}, {duration: 2});
-new Animation(document.querySelector("#e"), {left: [{offset: 0, value: "100px"}, {offset: 1, value: "200px"}]}, {duration: 2});
-new Animation(document.querySelector("#f"), {left: [{offset: 0, value: "200px"}, {offset: 0.25, value: "100px"}, {offset: 1, value: "200px"}]}, {duration: 2});
-new Animation(document.querySelector("#g"), {left: [{offset: 0.25, value: "200px"}, {offset: 0.5, value: "100px"}, {offset: 0.75, value: "200px"}], operation: "add"}, {duration: 2});
+new Animation(document.querySelector("#e"), {left: [
+  {offset: 0, value: "100px"},
+  {offset: 1, value: "200px"}
+]}, {duration: 2});
+new Animation(document.querySelector("#f"), {left: [
+  {offset: 0, value: "200px"},
+  {offset: 0.25, value: "100px"},
+  {offset: 1, value: "200px"}
+]}, {duration: 2});
+new Animation(document.querySelector("#g"), {left: [
+  {offset: 0.25, value: "200px"},
+  {offset: 0.5, value: "100px"},
+  {offset: 0.75, value: "200px"}
+], operation: "add"}, {duration: 2});
 
 
 </script>

--- a/test-length-units.html
+++ b/test-length-units.html
@@ -42,7 +42,9 @@ table {
 
 </style>
 
-Each cell in the table will start at the first value for the column (e.g. 5em, 5ex, 50px, etc.), then animate to the second value for the column (e.g. 1em, 1ex, etc.), then animate to the 'to' value for the row.
+Each cell in the table will start at the first value for the column (e.g. 5em,
+5ex, 50px, etc.), then animate to the second value for the column (e.g. 1em,
+1ex, etc.), then animate to the 'to' value for the row.
 
 <table></table>
 
@@ -66,7 +68,9 @@ for (var j = 0; j < to.length; j++) {
   for (var i = 0; i < from.length; i++) {
     fromVal = from[i];
     id = 'a' + toVal + fromVal;
-    table += "<td><div class='container'><div class='expectation' style='width: " + toVal + "'</div><div id="+id+" class='anim'></div></div></td>"
+    table +=
+        "<td><div class='container'><div class='expectation' style='width: " +
+        toVal + "'</div><div id="+id+" class='anim'></div></div></td>";
     anims['#' + id] = [to[i], fromVal, toVal];
   }
   table += "</tr>"

--- a/test-parent.html
+++ b/test-parent.html
@@ -17,25 +17,25 @@ limitations under the License.
 <!DOCTYPE html>
 <style>
 .anim {
-	left: 0px;
-	width: 100px;
-	height: 25px;
-	background-color: #FAA;
-	position: relative;
+  left: 0px;
+  width: 100px;
+  height: 25px;
+  background-color: #FAA;
+  position: relative;
 }
-.expected {
-	border-right: 1px solid black;
+.expect {
+  border-right: 1px solid black;
 }
 
 </style>
 
 <div>Right edge of each box should align with black line at end of test.</div>
-<div style="width: 300px;" class="expected"><div id="a" class="anim"></div></div>
-<div style="width: 300px;" class="expected"><div id="b" class="anim"></div></div>
-<div style="width: 100px;" class="expected"><div id="c" class="anim"></div></div>
-<div style="width: 300px;" class="expected"><div id="d" class="anim"></div></div>
-<div style="width: 300px;" class="expected"><div id="e" class="anim"></div></div>
-<div style="width: 100px;" class="expected"><div id="f" class="anim"></div></div>
+<div style="width: 300px;" class="expect"><div id="a" class="anim"></div></div>
+<div style="width: 300px;" class="expect"><div id="b" class="anim"></div></div>
+<div style="width: 100px;" class="expect"><div id="c" class="anim"></div></div>
+<div style="width: 300px;" class="expect"><div id="d" class="anim"></div></div>
+<div style="width: 300px;" class="expect"><div id="e" class="anim"></div></div>
+<div style="width: 100px;" class="expect"><div id="f" class="anim"></div></div>
 
 <script src="web-animation.js"></script>
 <script>
@@ -49,11 +49,10 @@ new Animation(document.getElementById("b"), {left: ["100px", "200px"]}, 1.0,
 new Animation(document.getElementById("c"), {left: ["100px", "200px"]}, 1.0,
               null);
 
-// Animationation in group with default parent. Should use default group.
+// Animation in group with default parent. Should use default group.
 new Animation(document.getElementById("d"), {left: ["100px", "200px"]}, 1.0,
               new ParGroup([], {iterationCount: 3}));
-// Animationation in group with explicit default parent. Should use default
-// group.
+// Animation in group with explicit default parent. Should use default group.
 new Animation(document.getElementById("e"), {left: ["100px", "200px"]}, 1.0,
               new ParGroup([], {iterationCount: 3}, undefined));
 // Animationation in group with explicit no parent. Should use no group.

--- a/test-path.html
+++ b/test-path.html
@@ -50,8 +50,10 @@ height: 500px;
 </style>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-    <path id=path1 d="M 100,100 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0 " stroke="black" stroke-width="1" fill="none" />
-    <path id=path2 d="M 100 250 L 300 250 L 200 450 z" stroke="black" stroke-width="1" fill="none" />
+  <path id=path1 d="M 100,100 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0 "
+      stroke="black" stroke-width="1" fill="none" />
+  <path id=path2 d="M 100 250 L 300 250 L 200 450 z" stroke="black"
+      stroke-width="1" fill="none" />
 </svg>
 
 <div id="e1" class="expectation"></div>
@@ -67,15 +69,12 @@ var animFunc = new PathAnimationFunction(
     document.querySelector('#path1'));
 animFunc.rotate = true;
 
-var anim = new Animation(document.querySelector("#anim1"),
-    animFunc,
+new Animation(document.querySelector("#anim1"), animFunc,
     {duration: 2, iterationCount: 2});
 
-var animFunc2 = new PathAnimationFunction(
-    document.querySelector('#path2'));
+var animFunc2 = new PathAnimationFunction(document.querySelector('#path2'));
 animFunc2.rotate = true;
 
-var anim2 = new Animation(document.querySelector("#anim2"),
-    animFunc2,
+new Animation(document.querySelector("#anim2"), animFunc2,
     {duration: 2, iterationCount: 2});
 </script>

--- a/test-pause.html
+++ b/test-pause.html
@@ -17,27 +17,27 @@ limitations under the License.
 <!DOCTYPE html>
 <style>
 .anim {
-	left: 0px;
-	width: 100px;
-	height: 100px;
-	background-color: lightsteelblue;
-	position: absolute;
+  left: 0px;
+  width: 100px;
+  height: 100px;
+  background-color: lightsteelblue;
+  position: absolute;
 }
 
 #a {
-	top: 0px
+  top: 0px
 }
 
 #b {
-	top: 100px;
+  top: 100px;
 }
 
 #c {
-	top: 200px;
+  top: 200px;
 }
 
 #d {
-	top: 300px;
+  top: 300px;
 }
 
 #expectation {
@@ -53,36 +53,40 @@ limitations under the License.
 <div id=expectation></div>
 
 <div>
-	<div id="a" class="anim a"></div>
-	<div id="b" class="anim b"></div>
+  <div id="a" class="anim a"></div>
+  <div id="b" class="anim b"></div>
 </div>
 
 <div id="fromTemplate">
-	<div id="c" class="anim a"></div>
-	<div id="d" class="anim b"></div>
+  <div id="c" class="anim a"></div>
+  <div id="d" class="anim b"></div>
 </div>
 
 <script src="web-animation.js"></script>
 <script>
 
-var a1 = new Animation(document.querySelector("#a"), {left: ["100px", "200px"]}, 2.6);
-var a2 = new Animation(document.querySelector("#b"), {left: ["100px", "200px"]}, 2.5);
-var a3 = new Animation(document.querySelector("#c"), {left: ["100px", "200px"]}, 2.5);
-var a4 = new Animation(document.querySelector("#d"), {left: ["100px", "200px"]}, 2.3);
+var a1 = new Animation(document.querySelector("#a"), {left: ["100px", "200px"]},
+    2.6);
+var a2 = new Animation(document.querySelector("#b"), {left: ["100px", "200px"]},
+    2.5);
+var a3 = new Animation(document.querySelector("#c"), {left: ["100px", "200px"]},
+    2.5);
+var a4 = new Animation(document.querySelector("#d"), {left: ["100px", "200px"]},
+    2.3);
 var pgroup1 = new ParGroup([a1, a2], {name: "p1"});
 var pgroup2 = new ParGroup([a3, a4], {name: "p2"});
 var sgroup = new SeqGroup([pgroup1, pgroup2], {name: "s"});
 
 window.setTimeout(function() {
-	sgroup.pause();
+  sgroup.pause();
 }, 1000);
 window.setTimeout(function() {
-	sgroup.play();
+  sgroup.play();
 }, 2000);
 window.setTimeout(function() {
-	sgroup.pause();
+  sgroup.pause();
 }, 4000);
 window.setTimeout(function() {
-	sgroup.play();
+  sgroup.play();
 }, 5000);
 </script>

--- a/test-playback-rate.html
+++ b/test-playback-rate.html
@@ -105,14 +105,27 @@ for (var i = 0; i < containers.length; i++) {
   // All squares should line up at the end of each iteration (or start if
   // reversed). All movement should be at the same speed.
   // Test basic use.
-  new Animation(container.getElementsByClassName("a")[0], {left: ["100px", "300px"]}, {duration: 1.0}, groups[i]);
-  new Animation(container.getElementsByClassName("b")[0], {left: ["100px", "300px"]}, {duration: 0.5, playbackRate: 0.5}, groups[i]);
-  new Animation(container.getElementsByClassName("c")[0], {left: ["100px", "300px"]}, {duration: 2.0, playbackRate: 2.0}, groups[i]);
+  new Animation(container.getElementsByClassName("a")[0],
+      {left: ["100px", "300px"]}, {duration: 1.0}, groups[i]);
+  new Animation(container.getElementsByClassName("b")[0],
+      {left: ["100px", "300px"]}, {duration: 0.5, playbackRate: 0.5},
+      groups[i]);
+  new Animation(container.getElementsByClassName("c")[0],
+      {left: ["100px", "300px"]}, {duration: 2.0, playbackRate: 2.0},
+      groups[i]);
    // Test negative values.
-  new Animation(container.getElementsByClassName("d")[0], {left: ["300px", "100px"]}, {duration: 1.0, playbackRate: -1.0}, groups[i]);
-  new Animation(container.getElementsByClassName("e")[0], {left: ["300px", "100px"]}, {duration: 0.5, playbackRate: -0.5}, groups[i]);
-  new Animation(container.getElementsByClassName("f")[0], {left: ["300px", "100px"]}, {duration: 2.0, playbackRate: -2.0}, groups[i]);
+  new Animation(container.getElementsByClassName("d")[0],
+      {left: ["300px", "100px"]}, {duration: 1.0, playbackRate: -1.0},
+      groups[i]);
+  new Animation(container.getElementsByClassName("e")[0],
+      {left: ["300px", "100px"]}, {duration: 0.5, playbackRate: -0.5},
+      groups[i]);
+  new Animation(container.getElementsByClassName("f")[0],
+      {left: ["300px", "100px"]}, {duration: 2.0, playbackRate: -2.0},
+      groups[i]);
    // Test zero.
-  new Animation(container.getElementsByClassName("g")[0], {left: ["300px", "100px"]}, {duration: 1.0, playbackRate: 0.0}, groups[i]);
+  new Animation(container.getElementsByClassName("g")[0],
+      {left: ["300px", "100px"]}, {duration: 1.0, playbackRate: 0.0},
+      groups[i]);
 }
 </script>

--- a/test-rectangle.html
+++ b/test-rectangle.html
@@ -30,11 +30,14 @@ position: absolute;
   background: red;
 }
 </style>
-<div id=expectation></div>
-<div id=test></div>
+<div id="expectation"></div>
+<div id="test"></div>
 <script src="web-animation.js"></script>
 <script>
-var anim = {'clip': ['rect(300px, 400px, 300px, 400px)', 'rect(0px, 800px, 600px, 0px)']};
+var anim = {'clip': [
+  'rect(300px, 400px, 300px, 400px)',
+  'rect(0px, 800px, 600px, 0px)'
+]};
 var timing = 1;
 new Animation(document.querySelector('#test'), anim, timing);
 </script>

--- a/test-reparent.html
+++ b/test-reparent.html
@@ -32,17 +32,21 @@ limitations under the License.
 
 <div>Right edge of each box should align with black line at end of test.</div>
 
-<div style="width: 400px;" class="expected"><div id="a" class="anim"></div></div>
+<div style="width: 400px;" class="expected">
+  <div id="a" class="anim"></div>
+</div>
 
 <script src="web-animation.js"></script>
 <script>
 
 // Run an animation in the global group. It should animate indefinitely.
-var anim = new Animation(document.getElementById("a"), {left: ["100px", "500px"]}, {iterationCount: Infinity, duration: 1.0});
+var anim = new Animation(document.getElementById("a"),
+    {left: ["100px", "500px"]}, {iterationCount: Infinity, duration: 1.0});
 
 // After 2.5s, move it to a parallel group and run that.
 setTimeout(function() {
-  new ParGroup([anim], {direction: "alternate", duration: 2.0, iterationCount: 2.0});
+  new ParGroup([anim], {direction: "alternate", duration: 2.0,
+      iterationCount: 2.0});
 }, 2500);
 
 // Move it to a new group and run that.

--- a/test-seq-speed.html
+++ b/test-seq-speed.html
@@ -17,27 +17,27 @@ limitations under the License.
 <!DOCTYPE html>
 <style>
 .anim {
-	left: 0px;
-	width: 100px;
-	height: 100px;
-	background-color: lightsteelblue;
-	position: absolute;
+  left: 0px;
+  width: 100px;
+  height: 100px;
+  background-color: lightsteelblue;
+  position: absolute;
 }
 
 #a {
-	top: 0px
+  top: 0px
 }
 
 #b {
-	top: 100px;
+  top: 100px;
 }
 
 #c {
-	top: 200px;
+  top: 200px;
 }
 
 #d {
-	top: 300px;
+  top: 300px;
 }
 
 #expectation {
@@ -53,28 +53,32 @@ limitations under the License.
 <div id=expectation></div>
 
 <div>
-	<div id="a" class="anim a"></div>
-	<div id="b" class="anim b"></div>
+  <div id="a" class="anim a"></div>
+  <div id="b" class="anim b"></div>
 </div>
 
 <div id="fromTemplate">
-	<div id="c" class="anim a"></div>
-	<div id="d" class="anim b"></div>
+  <div id="c" class="anim a"></div>
+  <div id="d" class="anim b"></div>
 </div>
 
 <script src="web-animation.js"></script>
 <script>
 
-var a1 = new Animation(document.querySelector("#a"), {left: ["100px", "200px"]}, 0.6);
-var a2 = new Animation(document.querySelector("#b"), {left: ["100px", "200px"]}, 0.5);
-var a3 = new Animation(document.querySelector("#c"), {left: ["100px", "200px"]}, 0.5);
-var a4 = new Animation(document.querySelector("#d"), {left: ["100px", "200px"]}, 0.3);
+var a1 = new Animation(document.querySelector("#a"), {left: ["100px", "200px"]},
+    0.6);
+var a2 = new Animation(document.querySelector("#b"), {left: ["100px", "200px"]},
+    0.5);
+var a3 = new Animation(document.querySelector("#c"), {left: ["100px", "200px"]},
+    0.5);
+var a4 = new Animation(document.querySelector("#d"), {left: ["100px", "200px"]},
+    0.3);
 var pgroup1 = new ParGroup([a1, a2], {name: "p1"});
 var pgroup2 = new ParGroup([a3, a4], {name: "p2"});
 var sgroup = new SeqGroup([pgroup1, pgroup2], {name: "s"});
 
 window.setTimeout(function() {
-	sgroup.timing.playbackRate = 2;
-	sgroup.play();
+  sgroup.timing.playbackRate = 2;
+  sgroup.play();
 }, 2000);
 </script>

--- a/test-start-time-iterations.html
+++ b/test-start-time-iterations.html
@@ -97,8 +97,12 @@ var animation = {left: ["100px", "500px"]};
 
 // We use a new group for each animation to avoid coupling due to the intrinsic
 // duration of a par group.
-var group = function(dir) { return new ParGroup([], {iterationCount: 2.0, direction: dir}); };
-var groupWithFixedDuration = function(dir) { return new ParGroup([], {iterationCount: 2.0, direction: dir, duration: 4.0}); };
+var group = function(dir) {
+  return new ParGroup([], {iterationCount: 2.0, direction: dir});
+};
+var groupWithFixedDuration = function(dir) {
+  return new ParGroup([], {iterationCount: 2.0, direction: dir, duration: 4.0});
+};
 
 for (var i = 0; i < directions.length; i++) {
   var container = document.getElementById(containers[i]);
@@ -106,8 +110,10 @@ for (var i = 0; i < directions.length; i++) {
         
   // Interaction of start time with parent iterations. Each child should
   // complete the full animation, starting 1.0s into the parent iteration.
-  new Animation(container.getElementsByClassName("a")[0], animation, {duration: 1.0}, group(dir), 1.0);
-  new Animation(container.getElementsByClassName("b")[0], animation, {duration: 1.0}, groupWithFixedDuration(dir), 1.0);
+  new Animation(container.getElementsByClassName("a")[0], animation,
+      {duration: 1.0}, group(dir), 1.0);
+  new Animation(container.getElementsByClassName("b")[0], animation,
+      {duration: 1.0}, groupWithFixedDuration(dir), 1.0);
   // Interaction of default start time with parent iterations. At the time of
   // addition, the first group has a duration, and hence iteration time of
   // zero, so the child picks up a start time of zero.  The parent then updates
@@ -117,9 +123,13 @@ for (var i = 0; i < directions.length; i++) {
   // time, so plays the complete animation. In iterations where the parent
   // plays backwards, the above is reversed. Also, if the first iteration plays
   // backwards, the child will miss it altogether.
-  setTimeout(function(container, group1, group2) { return function() {
-    new Animation(container.getElementsByClassName("c")[0], animation, {duration: 1.0}, group1);
-    new Animation(container.getElementsByClassName("d")[0], animation, {duration: 1.0}, group2);
-  }; }(container, group(dir), groupWithFixedDuration(dir)), 500);
+  setTimeout(function(container, group1, group2) {
+    return function() {
+      new Animation(container.getElementsByClassName("c")[0], animation,
+          {duration: 1.0}, group1);
+      new Animation(container.getElementsByClassName("d")[0], animation,
+          {duration: 1.0}, group2);
+    };
+  }(container, group(dir), groupWithFixedDuration(dir)), 500);
 }
 </script>

--- a/test-start-time.html
+++ b/test-start-time.html
@@ -78,37 +78,49 @@ var animation = {left: ["100px", "300px"]};
 for (var i = 0; i < directions.length; i++) {
   var container = document.getElementById(containers[i]);
   // Explicit child start time and parent duration.
-  new Animation(container.getElementsByClassName("a")[0], animation, {duration: 1.0},
-      new ParGroup([], {iterationCount: 2.0, direction: directions[i], duration: 1.0}), 0.0);
+  new Animation(container.getElementsByClassName("a")[0], animation,
+      {duration: 1.0},
+      new ParGroup([], {iterationCount: 2.0, direction: directions[i],
+          duration: 1.0}),
+      0.0);
   // Explicit child start time, parent calculates intrinsic duration.
-  new Animation(container.getElementsByClassName("b")[0], animation, {duration: 1.0},
-      new ParGroup([], {iterationCount: 2.0, direction: directions[i]}), 0.0);
+  new Animation(container.getElementsByClassName("b")[0], animation,
+      {duration: 1.0},
+      new ParGroup([], {iterationCount: 2.0, direction: directions[i]}),
+      0.0);
   // Default child start time, explicit parent duration. Note that for "normal"
   // parent, child start time will be 0.0, so animation proceeds as above. For
   // "reverse" parent, child start time will be 1.0 and maximum parent
   // iteration time is 1.0, so animation never runs.
-  new Animation(container.getElementsByClassName("c")[0], animation, {duration: 1.0},
-      new ParGroup([], {iterationCount: 2.0, direction: directions[i], duration: 1.0}));
+  new Animation(container.getElementsByClassName("c")[0], animation,
+      {duration: 1.0},
+      new ParGroup([], {iterationCount: 2.0, direction: directions[i],
+          duration: 1.0}));
   // Default child start time, explicit parent duration, plus explicit parent
   // group zero start time. As above, but we have to extend the parent duration
   // to avoid the "normal" child animation being clipped. This is because
   // forcing a parent start time of zero means that the parent starts with a
   // non-zero iteration time, which is used as the child start time, causing
   // the child end time to exceed 1.0.
-  new Animation(container.getElementsByClassName("d")[0], animation, {duration: 1.0},
-      new ParGroup([], {iterationCount: 2.0, direction: directions[i], duration: 2.0}, undefined, 0.0));
+  new Animation(container.getElementsByClassName("d")[0], animation,
+      {duration: 1.0},
+      new ParGroup([], {iterationCount: 2.0, direction: directions[i],
+          duration: 2.0}, undefined, 0.0));
   // Default child start time, explicit parent duration, plus explicit parent
   // group non-zero start time. Note that for both "normal" and "reverse"
   // parents, parent iteration time is null, so child start time is zero, and
   // animation proceeds as above. 
-  new Animation(container.getElementsByClassName("e")[0], animation, {duration: 1.0},
-      new ParGroup([], {iterationCount: 2.0, direction: directions[i], duration: 1.0}, undefined, 0.5));
+  new Animation(container.getElementsByClassName("e")[0], animation,
+      {duration: 1.0},
+      new ParGroup([], {iterationCount: 2.0, direction: directions[i],
+          duration: 1.0}, undefined, 0.5));
   // Default child start time and parent duration. Note that for "normal"
   // parent, child start time will be 0.0, so animation proceeds as above. For
   // "reverse" parent, child start time will be 0.0, as this is the parent
   // iteration time at the time of creation, but maximum parent iteration time
   // is 1.0, so animation proceeds as above.
-  new Animation(container.getElementsByClassName("f")[0], animation, {duration: 1.0},
+  new Animation(container.getElementsByClassName("f")[0], animation,
+      {duration: 1.0},
       new ParGroup([], {iterationCount: 2.0, direction: directions[i]}));
 }
 </script>

--- a/test-svg-anim.html
+++ b/test-svg-anim.html
@@ -25,8 +25,9 @@ limitations under the License.
 }
 </style>
 <svg>
-	<rect class="expectation" x="400px" y="10px" width="100px" height="100px"></rect>
-	<rect class="anim" x="100px" y="10px" width="100px" height="100px"></rect>
+  <rect class="expectation" x="400px" y="10px" width="100px" height="100px">
+  <rect>
+  <rect class="anim" x="100px" y="10px" width="100px" height="100px"></rect>
 </svg>
 <script src="web-animation.js"></script>
 <script>

--- a/test-timing-functions.html
+++ b/test-timing-functions.html
@@ -35,7 +35,7 @@ limitations under the License.
 body { margin: 0px; }
 </style>
 
-<div id=expectation></div>
+<div id="expectation"></div>
 
 <div>
   <div id="a" class="anim">(default)</div>
@@ -51,10 +51,12 @@ body { margin: 0px; }
 <script src="web-animation.js"></script>
 <script>
 
-new Animation(document.querySelector("#a"), {left: "200px"}, {startDelay: 1, duration: 2});
+new Animation(document.querySelector("#a"), {left: "200px"},
+    {startDelay: 1, duration: 2});
 var elems = document.querySelectorAll(".test");
 for (var i = 0; i < elems.length; i++) {
   var element = elems[i];
-  new Animation(element, {left: "200px"}, {startDelay: 1, duration: 2, timingFunction: element.textContent});
+  new Animation(element, {left: "200px"},
+      {startDelay: 1, duration: 2, timingFunction: element.textContent});
 }
 </script>

--- a/test-to-animation.html
+++ b/test-to-animation.html
@@ -17,38 +17,38 @@ limitations under the License.
 <!DOCTYPE html>
 <style>
 .anim {
-	left: 0px;
-	width: 100px;
-	height: 100px;
-	background-color: lightsteelblue;
-	position: absolute;
+  left: 0px;
+  width: 100px;
+  height: 100px;
+  background-color: lightsteelblue;
+  position: absolute;
 }
 
 #a {
-	top: 0px;
-	left: 200px;
+  top: 0px;
+  left: 200px;
 }
 
 #b {
-	top: 100px;
-	left: 100px;
+  top: 100px;
+  left: 100px;
 }
 
 #c {
-	top: 200px;
-	left: 0px;
+  top: 200px;
+  left: 0px;
 }
 
 #d {
-	top: 300px;
-	left: 200px;
+  top: 300px;
+  left: 200px;
 }
 
 .expectation {
-	background-color: red;
-	position: absolute;
-	width: 100px;
-	height: 100px;
+  background-color: red;
+  position: absolute;
+  width: 100px;
+  height: 100px;
 }
 
 </style>
@@ -59,10 +59,10 @@ limitations under the License.
 <div class="expectation" style="top: 300px; left: 400px;"></div>
 
 <div>
-	<div id="a" class="anim"></div>
-	<div id="b" class="anim"></div>
-	<div id="c" class="anim"></div>
-	<div id="d" class="anim"></div>
+  <div id="a" class="anim"></div>
+  <div id="b" class="anim"></div>
+  <div id="c" class="anim"></div>
+  <div id="d" class="anim"></div>
 </div>
 
 <script src="web-animation.js"></script>
@@ -73,7 +73,7 @@ var divs = document.querySelectorAll(".anim");
 var group = new ParGroup([], 2, undefined, 1);
 
 for (var i = 0; i < divs.length; i++) {
-	var anim = new Animation(divs[i], {left: (100 * (i+1)) + "px"}, 2, group);
+  new Animation(divs[i], {left: (100 * (i+1)) + "px"}, 2, group);
 }
 
 </script>

--- a/web-animation-test.html
+++ b/web-animation-test.html
@@ -20,36 +20,36 @@ limitations under the License.
 
 <style>
 .anim {
-	top: 0px;
-	left: 0px;
-	width: 100px;
-	height: 100px;
-	background-color: #FAA;
-	position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100px;
+  height: 100px;
+  background-color: #FAA;
+  position: absolute;
 }
 
 .red {
-	background-color: red;
+  background-color: red;
 }
 
 .green {
-	background-color: green;
+  background-color: green;
 }
 
 .blue {
-	background-color: blue;
+  background-color: blue;
 }
 
 #a {
-	top: 100px;
+  top: 100px;
 }
 
 #b {
-	top: 200px;
+  top: 200px;
 }
 
 #c {
-	top: 300px;
+  top: 300px;
 }
 
 </style>
@@ -57,17 +57,17 @@ limitations under the License.
 </div>
 
 <div>
-	<div id="a" class="anim"></div>
-	<div id="b" class="anim"></div>
+  <div id="a" class="anim"></div>
+  <div id="b" class="anim"></div>
 </div>
 <div>
-	<div id="c" class="anim"></div>
+  <div id="c" class="anim"></div>
 </div>
 
 <div class="group">
-	<div class="anim top red"></div>
-	<div class="anim right green"></div>
-	<div class="anim down blue"></div>
+  <div class="anim top red"></div>
+  <div class="anim right green"></div>
+  <div class="anim down blue"></div>
 </div>
 
 
@@ -75,20 +75,23 @@ limitations under the License.
 <script src="web-animation.js"></script>
 <script>
 
-var anim = new Anim(document.querySelector(".anim"), {left: ["100px", "200px"]}, {startDelay: 2, duration: 4}, undefined, 1);
+new Anim(document.querySelector(".anim"), {left: ["100px", "200px"]},
+    {startDelay: 2, duration: 4}, undefined, 1);
 
 
 var up = new AnimTemplate({top: ["200px", "0px"]}, 1, "selector: .top");
-var right = new AnimTemplate({"left": ["0px", "200px"]}, {startDelay: 0.5, duration: 1}, "selector: .right");
-var down = new AnimTemplate({top: ["0px", "200px"]}, {startDelay: 1, duration: 1}, "selector: .down");
+var right = new AnimTemplate({"left": ["0px", "200px"]},
+    {startDelay: 0.5, duration: 1}, "selector: .right");
+var down = new AnimTemplate({top: ["0px", "200px"]},
+    {startDelay: 1, duration: 1}, "selector: .down");
 
 var group = new ParAnimGroupTemplate([up, right, down]);
 group.animate(document.querySelector(".group"), 0);
 
 var group = new SeqAnimGroupTemplate([
-	new AnimTemplate({left: ["100px", "150px"]}, 1, "target: a"),
-	new AnimTemplate({left: ["100px", "150px"]}, 1, "target: b"),
-	new AnimTemplate({left: ["100px", "150px"]}, 1, "target: c")
+  new AnimTemplate({left: ["100px", "150px"]}, 1, "target: a"),
+  new AnimTemplate({left: ["100px", "150px"]}, 1, "target: b"),
+  new AnimTemplate({left: ["100px", "150px"]}, 1, "target: c")
 ]);
 
 group.animate([[]], 0); // TODO fix this so that 0 children can be passed here.


### PR DESCRIPTION
This replaces tabs with spaces, and fixes indentation.

We're about to mess with all of the tests when we add the 'attach()' syntax for TimeSources, so this seems like a good time to clean this up.
