### PR TITLE
Restart the polyfill ticker when setting properties on a TimedItem

### DIFF
--- a/test/test-harness.html
+++ b/test/test-harness.html
@@ -44,6 +44,7 @@ var tests = [
   'test-preset-timings.html',
   'test-rectangle.html',
   'test-reparent.html',
+  'test-restart.html',
   'test-seq-speed.html',
   'test-set-parent.html',
   'test-start-time-iterations.html',

--- a/test/testcases/test-restart.html
+++ b/test/testcases/test-restart.html
@@ -1,0 +1,95 @@
+<!--
+Copyright 2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html>
+<style>
+body {
+  background-color: green;
+}
+body div#fail {
+  display: none;
+}
+body.fail {
+  background-color: red;
+}
+body.fail div#pass {
+  display: none;
+}
+body.fail div#fail {
+  display: block;
+}
+div.anim {
+  position: relative;
+  left: 0px;
+}
+</style>
+
+<div id="pass">PASS</div>
+<div id="fail">FAIL</div>
+<div id="anim1" class="anim"></div>
+<div id="anim2" class="anim"></div>
+
+<script src="../../web-animation.js"></script>
+<script>
+
+var fail = function(failureMessage) {
+  var div = document.createElement("div");
+  div.innerText = failureMessage;
+  document.body.appendChild(div);
+  document.body.className = "fail";
+};
+
+var check = function(actual, expected, failureMessage) {
+  if (actual != expected) {
+    fail(failureMessage + ". Expected '" + expected + "', got '" + actual +
+        "'.");
+  }
+};
+
+var animFunc = {left: "100px"};
+var anim1 = new Animation(document.getElementById("anim1"), animFunc, 1.0);
+var anim2 = new Animation(document.getElementById("anim2"), animFunc, 1.0);
+
+// Check that once an animation is completed, play() restarts it.
+anim1.currentTime = 1.0;
+setTimeout(function() {
+  check(getComputedStyle(anim1.targetElement).left, "100px",
+      "Animation 1 should be in end state");
+  anim1.play();
+  setTimeout(function() {
+    check(parseInt(getComputedStyle(anim1.targetElement).left) > 0, true,
+        "Animation 1 should not be in start state");
+    check(parseInt(getComputedStyle(anim1.targetElement).left) < 100, true,
+        "Animation 1 should not be in end state");
+  }, 100);
+}, 100);
+
+// Check that once an animation is completed, setting currentTime = 0 restarts
+// it.
+anim2.currentTime = 1.0;
+setTimeout(function() {
+  check(getComputedStyle(anim2.targetElement).left, "100px",
+      "Animation 2 should be in end state");
+  anim2.currentTime = 0.0;
+  setTimeout(function() {
+    check(parseInt(getComputedStyle(anim2.targetElement).left) > 0, true,
+        "Animation 2 should not be in start state");
+    check(parseInt(getComputedStyle(anim2.targetElement).left) < 100, true,
+        "Animation 2 should not be in end state");
+  }, 100);
+}, 100);
+
+</script>

--- a/web-animation.js
+++ b/web-animation.js
@@ -432,6 +432,7 @@ mixin(TimedItem.prototype, {
     } else {
       this._updateIterationParams();
     }
+    maybeRestartAnimation();
     return this._timeFraction !== null;
   },
   // Takes a time in our iteration time space and converts it to the our
@@ -504,7 +505,6 @@ mixin(TimedItem.prototype, {
     }
   },
   play: function() {
-    // TODO: This should unpause as well
     if (this.currentTime > this.animationDuration + this.timing.startDelay &&
         this.timing.playbackRate >= 0) {
       this.currentTime = this.timing.startDelay;


### PR DESCRIPTION
This is required to make sure that the polyfill starts animating if no
animations are currently active, but an animation's properties are modified
such that it becomes active.

This fixes https://github.com/web-animations/web-animations-js/issues/86

Also fix a stale TODO.
