### PR TITLE
Use the document load event as the zero point for document time

### DIFF
--- a/test/testcases/test-document-timeline.html
+++ b/test/testcases/test-document-timeline.html
@@ -35,6 +35,7 @@ body.fail div#fail {
 
 <div id="pass">PASS</div>
 <div id="fail">FAIL</div>
+<div id="anim"></div>
 
 <script src="../../web-animation.js"></script>
 <script>
@@ -52,9 +53,47 @@ var checkNotEqual = function(actual, unexpected, failureMessage) {
   }
 };
 
+var check = function(actual, expected, failureMessage) {
+  if (actual != expected) {
+    fail(failureMessage + ". Expected '" + expected + "', got '" + actual +
+        "'.");
+  }
+};
+
+var clockMillis = function() {
+  return typeof performance === "object" &&
+      typeof performance.now === "function" ?
+      performance.now() : Date.now();
+};
+
+function sleep() {
+  var startTime = clockMillis();
+  while (startTime === clockMillis()) {}
+}
+
 // Test that document.timeline.currentTime is read-only.
 document.timeline.currentTime = 1;
 checkNotEqual(document.timeline.currentTime, 1,
     "document.timeline.currentTime should be read-only");
+
+// Test that document.timeline.currentTime is null before the document load
+// event.
+check(document.timeline.currentTime, null,
+    "document.timeline.currentTime should be null before document load event");
+
+// Test that Player.currentTime is null before the document load event.
+var animation = new Animation(document.getElementById("anim"), {left: "100px"});
+check(document.timeline.createPlayer(animation).currentTime, null,
+    "Player.currentTime should be null before document load event");
+
+// Test that document.timeline.currentTime is constant within a JavaScript
+// callstack.
+setTimeout(function() {
+  var time = document.timeline.currentTime;
+  sleep();
+  check(document.timeline.currentTime, time,
+      "document.timeline.currentTime time should be constant in JavaScript " +
+      "callstack");
+}, 0);
 
 </script>

--- a/test/testcases/test-player.html
+++ b/test/testcases/test-player.html
@@ -79,10 +79,8 @@ check(animation.getPlayer(), player2,
     "Repeated createPlayer(): TimedItem.getPlayer() incorrect");
 check(player2.timedItem, animation,
     "Repeated createPlayer(): Player.timedItem incorrect");
-check(player2.startTime > player1.startTime, true,
-    "Repeated createPlayer(): player2 should have later start time");
-check(player2.currentTime < player1.currentTime, true,
-    "Repeated createPlayer(): player1 should have later current time");
+check(player2.startTime, player1.startTime,
+    "Repeated createPlayer(): players should have same start time");
 
 // Test explicit setting of Player.timedItem.
 player1.timedItem = animation;

--- a/test/testcases/test-repeated-pause.html
+++ b/test/testcases/test-repeated-pause.html
@@ -74,8 +74,8 @@ setTimeout(function() {
   setTimeout(function() {
     currentTime = player.currentTime;
     player.unpause();
-    check(player.currentTime > currentTime, true, "Player.currentTime should " +
-        "be unaffected by repeated calls to Player.unpause()");
+    check(player.currentTime, currentTime, "Player.currentTime should be " +
+        "unaffected by repeated calls to Player.unpause()");
   }, 100);
 }, 100);
 


### PR DESCRIPTION
Also make sure that the document time is null before this zero point, and add a
test to check that the document time is constant within a JavaScript
callstack.

This fixes https://github.com/web-animations/web-animations-js/issues/101
