### PR TITLE
Converting to assert_approx_equal values which differ between Chrome stable/beta and unstable.

### DIFF
--- a/test/testcases/test-media.html
+++ b/test/testcases/test-media.html
@@ -244,7 +244,7 @@ var continuation12 = function() {
   player.currentTime = 1.0;
   raf(function() {
     test(function() {
-      assert_equals(video.currentTime, video.duration - 1.0);
+      assert_approx_equals(video.currentTime, video.duration - 1.0, 0.0001);
       assert_equals(video.playbackRate, -1.0);
     }, "Video should respect reversing");
     player.source = null;
@@ -259,7 +259,7 @@ var continuation13 = function() {
   player.currentTime = 1.0;
   raf(function() {
     test(function() {
-      assert_equals(video.currentTime, video.duration - 0.5);
+      assert_approx_equals(video.currentTime, video.duration - 0.5, 0.0001);
       assert_equals(video.playbackRate, -0.5);
     }, "Video should respect negative playbackRate");
     player.source = null;


### PR DESCRIPTION
See https://travis-ci.org/mithro/web-animations-js/builds/6650414
