### PR TITLE
fix for firefox

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -2891,19 +2891,19 @@ if (!raf) {
         callback(clockMillis());
       }, 1000/60);
     };
-  } else if (usePerformanceTiming) {
-    // platform requestAnimationFrame provides only millisecond accuracy, wrap
-    // it and use performance.now()
-    raf = function(callback) {
-      nativeRaf(function() {
-        callback(performance.now());
-      });
-    };
   } else {
-    // platform requestAnimationFrame provides only millisecond accuracy, and
-    // we can't do any better
     raf = nativeRaf;
   }
+}
+if (usePerformanceTiming) {
+  // platform requestAnimationFrame provides only millisecond accuracy, wrap
+  // it and use performance.now()
+  var _raf = raf;
+  raf = function(callback) {
+    _raf(function() {
+      callback(performance.now());
+    });
+  };
 }
 
 var clockMillis = function() {


### PR DESCRIPTION
Animations are not working Firefox 20.0 because its requestAnimationFrame callback passes the epoch time as an argument while the code expects performance.now(), and the code to wrap the callback to use performance.now() didn't catch this case.
