### PR TITLE
Pass parent filling state to child when updating iteration time.

### DIFF
--- a/test/testcases.js
+++ b/test/testcases.js
@@ -12,6 +12,7 @@ var tests = [
   'test-duration.html',
   'test-element-animate.html',
   'test-fill-values.html',
+  'test-fill-wrapping.html',
   'test-font-weight.html',
   'test-grouped-anim-func.html',
   'test-integer.html',

--- a/test/testcases/test-fill-wrapping-checks.js
+++ b/test/testcases/test-fill-wrapping-checks.js
@@ -1,0 +1,17 @@
+check(document.querySelectorAll('.anim')[0],{'left':'100px'},0);
+check(document.querySelectorAll('.anim')[1],{'left':'100px'},0);
+check(document.querySelectorAll('.anim')[2],{'left':'100px'},0);
+check(document.querySelectorAll('.anim')[3],{'left':'100px'},0);
+check(document.querySelectorAll('.anim')[0],{'left':'200px'},1);
+check(document.querySelectorAll('.anim')[1],{'left':'200px'},1);
+check(document.querySelectorAll('.anim')[2],{'left':'200px'},1);
+check(document.querySelectorAll('.anim')[3],{'left':'200px'},1);
+check(document.querySelectorAll('.anim')[0],{'left':'100px'},2);
+check(document.querySelectorAll('.anim')[1],{'left':'100px'},2);
+check(document.querySelectorAll('.anim')[2],{'left':'100px'},2);
+check(document.querySelectorAll('.anim')[3],{'left':'100px'},2);
+check(document.querySelectorAll('.anim')[0],{'left':'100px'},3);
+check(document.querySelectorAll('.anim')[1],{'left':'100px'},3);
+check(document.querySelectorAll('.anim')[2],{'left':'100px'},3);
+check(document.querySelectorAll('.anim')[3],{'left':'100px'},3);
+

--- a/test/testcases/test-fill-wrapping.html
+++ b/test/testcases/test-fill-wrapping.html
@@ -1,0 +1,69 @@
+<!--
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html>
+<style>
+.anim {
+  width: 100px;
+  height: 100px;
+  top: 100px;
+  left: 100px;
+  position: absolute;
+  background-color: lightsteelblue;
+}
+
+#inSeq {
+  top: 200px;
+}
+
+#inParDelayedStop {
+  top: 300px;
+}
+
+#inSeqDelayedStop {
+  top: 400px;
+}
+</style>
+<div class="anim" id="inPar"></div>
+<div class="anim" id="inSeq"></div>
+<div class="anim" id="inParDelayedStop"></div>
+<div class="anim" id="inSeqDelayedStop"></div>
+<div style="height: 500px"></div>
+<script src="../../web-animations.js"></script>
+<script src="../anim-test-pre.js"></script>
+<script>
+document.timeline.play(new ParGroup([
+  new Animation(document.querySelector("#inPar"), {left: ["100px", "200px"]}, 
+                {fillMode: "none", duration: 1})],
+  {fillMode: "forwards"}));
+
+document.timeline.play(new SeqGroup([
+  new Animation(document.querySelector("#inSeq"), {left: ["100px", "200px"]}, 
+                {fillMode: "none", duration: 1})],
+  {fillMode: "forwards"}));
+
+document.timeline.play(new ParGroup([
+  new Animation(document.querySelector("#inParDelayedStop"), 
+                {left: ["100px", "200px"]}, 
+                {fillMode: "none", duration: 1})],
+  {fillMode: "forwards", duration: 2}));
+
+document.timeline.play(new SeqGroup([
+  new Animation(document.querySelector("#inSeqDelayedStop"), 
+                {left: ["100px", "200px"]}, 
+                {fillMode: "none", duration: 1})],
+  {fillMode: "forwards", duration: 2}));
+</script>


### PR DESCRIPTION
This is a fix for #202.

Looking further I wonder why this is so stateful. Can we get away with always passing time values into the sample function and generating animation currentTimes, etc. on request?
