### PR TITLE
Fixed reference to script files in demo_example.html

### DIFF
--- a/demos/demo_example.html
+++ b/demos/demo_example.html
@@ -111,7 +111,7 @@ div#links {
   <a href="#" onclick="eighth()">eighth</a>
 </div>
 
-<script src="web-animations.js"></script>
+<script src="../web-animations.js"></script>
 <script>
 
 // STEP 1
@@ -186,4 +186,4 @@ function eighth() {
   group.play();
 }
 </script>
-<script src="web-animations-visualization.js"></script>
+<script src="../web-animations-visualization.js"></script>


### PR DESCRIPTION
There was a reference to web-animations.js and web-animations-visualization.js to the demos directory instead of one directory higher in demo_example.html
