### PR TITLE
Fixed web-animations-visualization.js's use of document.animationTimeline and use of play() in demo_example.html

### DIFF
--- a/demos/demo_example.html
+++ b/demos/demo_example.html
@@ -131,12 +131,12 @@ function second() {
 
 function third() {
   a.timing.timingFunc = TimingFunction.createFromString('ease-in');
-  a.play();
+  document.timeline.play(a);
 }
 
 function fourth() {
-  a.timing.timingFunc = TimingFunction.createFromString('[0, 0.2,0.8, 1]');
-  a.play();
+  a.timing.timingFunc = TimingFunction.createFromString('cubic-beziel(0, 0.2,0.8, 1)');
+  document.timeline.play(a);
 }
 
 // STEP 3
@@ -155,7 +155,7 @@ function sixth() {
   var dust = document.querySelector(".dust");
   var dustPuff = new Animation(dust, { opacity: ["0", "0.4", "0"] }, 0.3);
   group.add(new ParGroup([ pictureTilting, dustPuff ]));
-  group.play();
+  document.timeline.play(group);
 }
 
 // STEP 4
@@ -176,14 +176,14 @@ function seventh() {
   closeAnim.timing.timingFunc = a.timing.timingFunc;
   a.timing.timingFunc = null;
   group.splice(0, 0, closeAnim);
-  group.play();
+  document.timeline.play(group);
 }
 
 // STEP 5
 
 function eighth() {
   group.timing.playbackRate = 2;
-  group.play();
+  document.timeline.play(group);
 }
 </script>
 <script src="../web-animations-visualization.js"></script>

--- a/web-animations-visualization.js
+++ b/web-animations-visualization.js
@@ -65,7 +65,7 @@ function createText(x, y, data) {
 var default_rect = createRect("5%", "10px", "90%", "20px");
 visRoot.appendChild(default_rect);
 
-document.animationTimeline._vis = default_rect;
+document.timeline._vis = default_rect;
 */
 
 function updateRects(anim, startP, widthP, y) {
@@ -124,14 +124,14 @@ function round(num) {
 
 function webAnimVisUpdateAnims() {
 	var earliestStart = Infinity;
-	for (var i = 0; i < document.animationTimeline.children.length; i++) {
-		var child = document.animationTimeline.children[i];
+	for (var i = 0; i < document.timeline.getCurrentPlayers().length; i++) {
+		var child = document.timeline.getCurrentPlayers()[i];
 		if (child.timeDrift + child.startTime < earliestStart) {
 			earliestStart = child.timeDrift + child.startTime;
 		}
 	}
 	// want to set the zero point such that earliestStart is at 5%, and width s.t. 90% represents the distance between earliestStart and endTime.
-	var length = document.animationTimeline.endTime;
+	var length = document.timeline.endTime;
 	var width = 90 * length / (length - earliestStart);
 	var left = 90 - width + 5;
 
@@ -139,10 +139,10 @@ function webAnimVisUpdateAnims() {
 		return;
 	}
 
-	var results = updateRects(document.animationTimeline, left, width, 10);
+	var results = updateRects(document.timeline, left, width, 10);
 	var height = results[0];
 	var length = results[2];
-	var xPos = (document.animationTimeline.iterationTime - earliestStart) / (length - earliestStart) * 90 + 5;
+	var xPos = (document.timeline.iterationTime - earliestStart) / (length - earliestStart) * 90 + 5;
 	if (line == undefined && !isNaN(xPos)) {
 		line = createVLine(xPos + "%", "0px", (height + 20) + "px");
 		visRoot.appendChild(line);


### PR DESCRIPTION
I fixed the mistake in `web-animations-visualization.js` where it uses an outdated method of playing animations.

I also fixed fixed the outdated use of `play()` in `demo_example.html`.

This is meant to fix [#208](https://github.com/web-animations/web-animations-js/issues/208)
