### PR TITLE
Add accumulate argument to PathAnimationEffect constructor

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -1146,10 +1146,11 @@ AnimationEffect.prototype = {
 
 
 /** @constructor */
-var PathAnimationEffect = function(path, autoRotate, angle, composite) {
+var PathAnimationEffect = function(path, autoRotate, angle, composite,
+    accumulate) {
   enterModifyCurrentAnimationState();
   try {
-    AnimationEffect.call(this, constructorToken, composite);
+    AnimationEffect.call(this, constructorToken, composite, accumulate);
     // TODO: path argument is not in the spec -- seems useful since
     // SVGPathSegList doesn't have a constructor.
     this.autoRotate = isDefined(autoRotate) ? autoRotate : 'none';


### PR DESCRIPTION
This allows the accumulation attribute of a PathAnimationEffect to be set,
which previously was not possible.

Note that the patch [1] to fix this in the spec narrowly missed FPWD.

[1] https://dvcs.w3.org/hg/FXTF/rev/f55c175711df
