### PR TITLE
Fix MediaReference after switch to new Timing interface

### DIFF
--- a/demos/curtains.html
+++ b/demos/curtains.html
@@ -57,13 +57,13 @@ var duration = 2.0;
 video.addEventListener("loadeddata", function() {
   document.timeline.play(new SeqGroup([
     new ParGroup([
-      new Animation(leftCurtain, {width: "0px"}, {duration: duration}),
-      new Animation(rightCurtain, {width: "0px"}, {duration: duration}),
+      new Animation(leftCurtain, {width: "0px"}, {iterationDuration: duration}),
+      new Animation(rightCurtain, {width: "0px"}, {iterationDuration: duration}),
     ]),
     new MediaReference(video, {startDelay: -duration}),
     new ParGroup([
-      new Animation(leftCurtain, {width: "50%"}, {duration: duration}),
-      new Animation(rightCurtain, {width: "50%"}, {duration: duration}),
+      new Animation(leftCurtain, {width: "50%"}, {iterationDuration: duration}),
+      new Animation(rightCurtain, {width: "50%"}, {iterationDuration: duration}),
     ], {startDelay: -duration}),
   ]));
 });

--- a/test/disabled-testcases
+++ b/test/disabled-testcases
@@ -1,2 +1,5 @@
-test-change-playback-rate.html # Lots of problems
-test-media.html # Scripts fail before adding tests, test file passes erroneously.
+# Lots of problems
+test-change-playback-rate.html
+# Requires the test harness to allow tests to be added after page load. See
+# https://github.com/web-animations/web-animations-js/issues/321
+test-media.html

--- a/test/testcases/test-media.html
+++ b/test/testcases/test-media.html
@@ -106,6 +106,10 @@ https://code.google.com/p/chromium/issues/detail?id=121765.
     <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
     <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
   </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
 </div>
   
 <script src="../bootstrap.js" nochecks></script>
@@ -409,5 +413,22 @@ timing_test(function() {
 
 // Test limited seek ranges.
 // TODO: Need to find a video with limited seek ranges.
+
+// Test that video is paused when its MediaReference is detached from its
+// Player.
+timing_test(function() {
+  var video = getNextVideo();
+  var player;
+  at(0.0, function() {
+    player = dt.play(createTestMediaReference(video));
+  });
+  at(1.0, function() {
+    assert_false(video.paused);
+    player.source = null;
+  });
+  at(2.0, function() {
+    assert_true(video.paused);
+  });
+}, "Video should be paused when MediaReference is detached from its Player");
 
 </script>

--- a/test/testcases/test-media.html
+++ b/test/testcases/test-media.html
@@ -15,318 +15,399 @@ limitations under the License.
 -->
 
 <!DOCTYPE html>
-<video id="video"></video>
+<style type="text/css">
+video {
+  width: 100px;
+}
+</style>
 
-<script src="../bootstrap.js"></script>
+<!--
+Videos are taken from
+http://techslides.com/sample-webm-ogg-and-mp4-video-files-for-html5
+
+We serve them from a remote host to make sure they are served with a 206
+response code, to work around Chrome bug
+https://code.google.com/p/chromium/issues/detail?id=121765.
+-->
+<div id="videos">
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+  <video preload="auto">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.webm" type="video/webm">
+    <source src="http://web-animations.github.io/web-animations-js/test/testcases/small.mp4" type="video/mp4">
+  </video>
+</div>
+  
+<script src="../bootstrap.js" nochecks></script>
 <script>
 "use strict";
 
-var video = document.getElementById("video");
 var dt = document.timeline;
 
-// Don't use a local named requestAnimationFrame, to avoid potential problems
-// with hoisting.
-var raf = window.requestAnimationFrame || window.webkitRequestAnimationFrame ||
-    window.mozRequestAnimationFrame || window.msRequestAnimationFrame;
-
-
-// Test that looping has no effect.
-video.loop = true;
-new MediaReference(video);
-test(function() {assert_equals(video.loop,  false)},
-     "MediaReference should disable looping");
-
-// Test intrinsic iterationDuration is Infinity before video loads.
-mediaReference = new MediaReference(video);
-test(function() {assert_equals(mediaReference.iterationDuration,  Infinity)},
-     "Intrinsic iterationDuration should be Infinity before video loads");
-
-video.addEventListener("loadeddata", function() { continuation1(); });
-// Length is around 32s.
-addSourceToVideo("http://video.webmfiles.org/big-buck-bunny_trailer.webm");
-// Length is around 10s.
-addSourceToVideo("http://www.w3schools.com/html/mov_bbb.mp4");
-
-function addSourceToVideo(sourceString) {
-  var source = document.createElement("source");
-  source.setAttribute("src", sourceString);
-  video.appendChild(source);
+// Most of these tests require the video to have loaded before they run.
+// However, the test harness does not allow timing_test()s to be started after
+// the page has finished loading. This means that we can't add the video
+// dynamically then wait for it to load before testing.
+//
+// As a best-effort work-around, we include all videos in static HTML with
+// preload="auto" to hint to the browser that they should be loaded
+// immediately. However, this does not guarantee that they will be loaded when
+// the page's load event fires, so the tests are flaky.
+//
+// TODO: Fix the test runner to allow the use of async_test() with
+// timing_test(), which will allow the video elements to be created dynamically.
+// See https://github.com/web-animations/web-animations-js/issues/321
+var videos = document.getElementById("videos").getElementsByTagName('video');
+// Cache this length, as videos is a live NodeList.
+var numStaticVideos = videos.length;
+var nextIndex = 0;
+function getNextVideo() {
+  if (nextIndex >= numStaticVideos) {
+    throw new Error('No more videos!');
+  }
+  return videos[nextIndex++];
 }
 
-var continuation1 = function() {
-  // Test intrinsic iterationDuration.
-  test(function() {assert_equals(mediaReference.iterationDuration,  video.iterationDuration)},
-       "Intrinsic iterationDuration should be video iterationDuration");
+function createVideo() {
+  // Videos taken from
+  // http://techslides.com/sample-webm-ogg-and-mp4-video-files-for-html5
+  var video = document.createElement("video");
+  var webmSource = document.createElement("source");
+  webmSource.setAttribute("src", "small.webm");
+  webmSource.setAttribute("type", "video/webm");
+  video.appendChild(webmSource);
+  var mp4Source = document.createElement("source");
+  mp4Source.setAttribute("src", "small.mp4");
+  mp4Source.setAttribute("type", "video/mp4");
+  video.appendChild(mp4Source);
+  document.getElementById("videos").appendChild(video);
+  return video;
+}
 
-  // Test basic use.
-  var player = dt.play(mediaReference);
-  raf(function() {
-    raf(function() {
-      test(function() {assert_equals(video.playbackRate,  1.0)},
-     "Video should have playback rate of 1.0");
-      test(function() {assert_equals(video.paused,  false)},
-     "Video should be playing");
-      player.source = null;
-      continuation2();
-    });
+function testOnceVideosLoaded(callback, message) {
+  timing_test(function() {
+    at(0.0, callback);
+  }, message);
+}
+
+function createTestMediaReference(mediaElement, timing, parent) {
+  return new MediaReference(mediaElement, timing, parent, 0.0);
+}
+
+var expectedVideoLength = 5.568;
+
+
+// Test that MediaReference disables looping.
+test(function() {
+  var video = getNextVideo();
+  video.loop = true;
+  createTestMediaReference(video);
+  assert_false(video.loop);
+}, "MediaReference should disable looping");
+
+// Test intrinsic iteration duration before media loads.
+test(function() {
+  assert_equals(createTestMediaReference(createVideo()).iterationDuration,
+      Infinity);
+}, "Intrinsic iterationDuration should be Infinity before media loads");
+
+// Test intrinisc iteration duration.
+testOnceVideosLoaded(function() {
+  assert_approx_equals(
+      createTestMediaReference(getNextVideo()).iterationDuration,
+      expectedVideoLength, 0.001);
+}, "Intrinsic iteration duration should be media duration");
+
+// Test that iteration duration can be overridden.
+testOnceVideosLoaded(function() {
+  assert_equals(createTestMediaReference(getNextVideo(), 1.0).iterationDuration,
+      1.0);
+}, "Iteration duration should be overridable");
+
+// Test basic use.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video));
+    assert_equals(video.playbackRate,  1.0);
+    assert_false(video.paused);
   });
-};
+}, "Basic use");
 
-var continuation2 = function() {
-  // Test clipping where iterationDuration limits. Video should be frozen at end of
-  // iterationDuration.
-  var player = dt.play(new MediaReference(video, {iterationDuration: 3.0}));
-  player.paused = true;
-  player.currentTime = 3.0;
-  raf(function() {
-    test(function() {
-      assert_equals(video.currentTime, 3.0);
-      assert_equals(video.paused, true);
-    }, "Video should be frozen at iterationDuration");
-    player.source = null;
-    continuation3();
+// Test clipping where iterationDuration limits. Video should be frozen at end
+// of iterationDuration.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video, 3.0));
   });
-};
-
-var continuation3 = function() {
-  // Test clipping where video length limits. Video should be frozen at end for
-  // remainder of iterationDuration.
-  var player = dt.play(
-      new MediaReference(video, {iterationDuration: video.iterationDuration + 2}));
-  player.paused = true;
-  player.currentTime = video.iterationDuration + 1;
-  raf(function() {
-    test(function() {
-      assert_equals(video.currentTime, video.iterationDuration);
-      assert_equals(video.paused, true);
-    }, "Video should be frozen at end");
-    player.currentTime = video.iterationDuration + 2;
-    raf(function() {
-      test(function() {
-        assert_equals(video.currentTime, video.iterationDuration);
-        assert_equals(video.paused, true);
-      }, "Video should be frozen after end");
-      player.source = null;
-      continuation4();
-    });
+  at(3.0, function() {
+    assert_equals(video.currentTime, 3.0);
+    assert_true(video.paused);
   });
-};
-
-var continuation4 = function() {
-  // Test fill with iterationDuration limiting. Video should be frozen at end of
-  // iterationDuration.
-  var player = dt.play(new MediaReference(video, {iterationDuration: 1.0}));
-  player.currentTime = 2.0;
-  raf(function() {
-    test(function() {assert_equals(video.currentTime,  1.0)},
-     "Should freeze video at iterationDuration for fill");
-    test(function() {assert_equals(video.paused,  true)},
-     "Video should be frozen for fill");
-    player.source = null;
-    continuation5();
+  at(4.0, function() {
+    assert_equals(video.currentTime, 3.0);
+    assert_true(video.paused);
   });
-};
+}, "Video should be frozen at iterationDuration");
 
-var continuation5 = function() {
-  // Test fill with video length limiting. Video should be at end.
-  var player = dt.play(
-      new MediaReference(video, {iterationDuration: video.iterationDuration + 1}));
-  player.currentTime = video.iterationDuration + 2;
-  raf(function() {
-    test(function() {assert_equals(video.currentTime,  video.iterationDuration)},
-         "Should freeze video at end for fill");
-    player.source = null;
-    continuation6();
+// Test clipping where video length limits. Video should be frozen at end for
+// remainder of iterationDuration.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video, video.duration + 2));
   });
-};
-
-var continuation6 = function() {
-  // Test no fill. Video should be frozen at start.
-  var player = dt.play(new MediaReference(video, {fillMode: "none"}));
-  player.currentTime = video.iterationDuration + 1;
-  raf(function() {
-    test(function() {assert_equals(video.currentTime,  0)},
-         "Should freeze video at start for no fill");
-    test(function() {assert_equals(video.paused,  true)},
-     "Video should be frozen for no fill");
-    player.source = null;
-    continuation7();
+  // We can't use video.duration here because the video isn't yet loaded.
+  at(expectedVideoLength + 1, function() {
+    assert_equals(video.currentTime, video.duration);
+    assert_true(video.paused);
   });
-};
-
-var continuation7 = function() {
-  // Test iterations.
-  var player = dt.play(new MediaReference(video,
-      {iterationCount: 2.0, iterationDuration: 1.0}));
-  player.paused = true;
-  player.currentTime = 1.5;
-  raf(function() {
-    test(function() {assert_equals(video.currentTime,  0.5)},
-     "Video should respect iterationCount");
-    player.source = null;
-    continuation8();
+  // We can't use video.duration here because the video isn't yet loaded.
+  at(expectedVideoLength + 2, function() {
+    assert_equals(video.currentTime, video.duration);
+    assert_true(video.paused);
   });
-};
+}, "Video should be frozen at end");
 
-var continuation8 = function() {
-  // Test iterationStart.
-  var player = dt.play(new MediaReference(video,
-      {iterationStart: 0.5, iterationDuration: 1.0}));
-  player.paused = true;
-  player.currentTime = 0;
-  raf(function() {
-    test(function() {assert_equals(video.currentTime,  0.5)},
-     "Video should respect iterationStart");
-    player.source = null;
-    continuation9();
+// Test fill with iterationDuration limiting. Video should be frozen at end of
+// iterationDuration.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video, 1.0));
   });
-};
-
-var continuation9 = function() {
-  // Test playback rate.
-  var player = dt.play(new MediaReference(video, {playbackRate: 2.0}));
-  player.paused = true;
-  player.currentTime = 1.0;
-  raf(function() {
-    test(function() {
-      assert_equals(video.currentTime, 2.0);
-      assert_equals(video.playbackRate, 2.0);
-    }, "Video should respect playbackRate");
-    player.source = null;
-    continuation10();
+  at(2.0, function() {
+    assert_equals(video.currentTime,  1.0);
+    assert_equals(video.paused,  true);
   });
-};
+}, "Should freeze video at iterationDuration for fill");
 
-var continuation10 = function() {
-  // Test heirachy of playback rates.
-  var player = dt.play(new ParGroup([
-    new MediaReference(video, {playbackRate: 2.0}),
-  ], {playbackRate: 3.0}));
-  player.paused = true;
-  player.currentTime = 1.0;
-  raf(function() {
-    test(function() {
-      assert_equals(video.currentTime, 6.0);
-      assert_equals(video.playbackRate, 6.0);
-    }, "Video should respect playbackRate heirachy");
-    player.source = null;
-    continuation11();
+// Test fill with video length limiting. Video should be at end.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video), video.duration + 1.0);
   });
-};
-
-var continuation11 = function() {
-  // Test interaction with MediaElement.defaultPlaybackRate.
-  video.defaultPlaybackRate = 4.0;
-  var player = dt.play(new MediaReference(video, {playbackRate: 1.5}));
-  player.paused = true;
-  player.currentTime = 1.0;
-  raf(function() {
-    test(function() {
-      assert_equals(video.currentTime, 6.0);
-      assert_equals(video.playbackRate, 6.0);
-    }, "Video should respect playbackRate after setting defaultPlaybackRate");
-    video.defaultPlaybackRate = 1.0;
-    player.source = null;
-    continuation12();
+  // We can't use video.duration here because the video isn't yet loaded.
+  at(expectedVideoLength + 2, function() {
+    assert_equals(video.currentTime,  video.duration);
   });
-};
+}, "Should freeze video at end for fill");
 
-var continuation12 = function() {
-  // Test reversing.
-  var player = dt.play(new MediaReference(video, {direction: "reverse"}));
-  player.paused = true;
-  player.currentTime = 1.0;
-  raf(function() {
-    test(function() {
-      assert_approx_equals(video.currentTime, video.iterationDuration - 1.0, 0.0001);
-      assert_equals(video.playbackRate, -1.0);
-    }, "Video should respect reversing");
-    player.source = null;
-    continuation13();
+// Test no fill. Video should be frozen at start.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video, {fillMode: "none"}));
   });
-};
-
-var continuation13 = function() {
-  // Test negative playback rate.
-  var player = dt.play(new MediaReference(video, {playbackRate: -0.5}));
-  player.paused = true;
-  player.currentTime = 1.0;
-  raf(function() {
-    test(function() {
-      assert_approx_equals(video.currentTime, video.iterationDuration - 0.5, 0.0001);
-      assert_equals(video.playbackRate, -0.5);
-    }, "Video should respect negative playbackRate");
-    player.source = null;
-    continuation14();
+  // We can't use video.duration here because the video isn't yet loaded.
+  at(expectedVideoLength + 1, function() {
+    assert_equals(video.currentTime,  0);
+    assert_equals(video.paused,  true);
   });
-};
+}, "Should freeze video at start for no fill");
 
-var continuation14 = function() {
-  // Test interaction of reversing and playback rate.
-  var player = dt.play(new ParGroup([
-    new MediaReference(video, {playbackRate: -0.5}),
-  ], {playbackRate: 3.0, direction: "reverse"}));
-  player.paused = true;
-  player.currentTime = 1.0;
-  raf(function() {
-    test(function() {
-      assert_equals(video.currentTime, 1.5);
-      assert_equals(video.playbackRate, 1.5);
-    }, "Video should respect reversing and playbackRate");
-    player.source = null;
-    continuation15();
+// Test iterations.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video,
+        {iterationCount: 2.0, iterationDuration: 1.0}));
   });
-};
-
-var continuation15 = function() {
-  // Test zero iterationDuration.
-  var player = dt.play(
-      new MediaReference(video, {iterationDuration: 0.0, iterationStart: 0.5}));
-  player.paused = true;
-  raf(function() {
-    test(function() {assert_equals(video.currentTime,  0.0)},
-         "Video should start at time zero when iterationDuration is zero");
-    player.currentTime = 1.0;
-    raf(function() {
-      test(function() {assert_equals(video.currentTime,  0.0)},
-           "Video should remain at time zero when iterationDuration is zero");
-      player.source = null;
-      continuation16();
-    });
+  at(1.5, function() {
+    assert_equals(video.currentTime,  0.5);
   });
-};
+}, "Video should respect iterationCount");
 
-var continuation16 = function() {
-  // Test zero intrinsic iterationDuration.
-  // TODO: Need to find a zero length video.
-  continuation17();
-};
+// Test iterationStart.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video,
+        {iterationStart: 0.5, iterationDuration: 2.0}));
+  });
+  at(0.5, function() {
+    assert_equals(video.currentTime,  1.5);
+  });
+}, "Video should respect iterationStart");
 
-var continuation17 = function() {
-  // Test that media elements are removed from their MediaController.
-  video.controller = new MediaController();
-  var player = dt.play(new MediaReference(video));
-  test(function() {assert_equals(video.controller,  null)},
-      "Video should be detached from controller when used in MediaReference");
+// Test playback rate.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video, {playbackRate: 2.0}));
+  });
+  at(1.0, function() {
+    assert_equals(video.currentTime, 2.0);
+    assert_equals(video.playbackRate, 2.0);
+  });
+}, "Video should respect playbackRate");
+
+// Test heirachy of playback rates.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(new ParGroup([createTestMediaReference(video, {playbackRate: 1.5})],
+        {playbackRate: 2.5}));
+  });
+  at(1.0, function() {
+    assert_equals(video.currentTime, 3.75);
+    assert_equals(video.playbackRate, 3.75);
+  });
+}, "Video should respect playbackRate heirachy");
+
+// Test interaction with MediaElement.defaultPlaybackRate.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    video.defaultPlaybackRate = 2.5;
+    dt.play(createTestMediaReference(video, {playbackRate: 1.5}));
+  });
+  at(1.0, function() {
+    assert_equals(video.currentTime, 3.75);
+    assert_equals(video.playbackRate, 3.75);
+  });
+}, "Video should respect playbackRate after setting defaultPlaybackRate");
+
+// Test reversing.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video, {direction: "reverse"}));
+  });
+  at(1.0, function() {
+    assert_approx_equals(video.currentTime, video.duration - 1.0, 0.0001);
+    assert_equals(video.playbackRate, -1.0);
+  });
+}, "Video should respect reversing");
+
+// Test negative playback rate.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video, {playbackRate: -0.5}));
+  });
+  at(1.0, function() {
+    assert_approx_equals(video.currentTime, video.duration - 0.5, 0.0001);
+    assert_equals(video.playbackRate, -0.5);
+  });
+}, "Video should respect negative playbackRate");
+
+// Test interaction of reversing and playback rate.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(new ParGroup(
+        [createTestMediaReference(video, {playbackRate: -0.5})],
+        {playbackRate: 3.0, direction: "reverse"}));
+  });
+  at(1.0, function() {
+    assert_equals(video.currentTime, 1.5);
+    assert_equals(video.playbackRate, 1.5);
+  });
+}, "Video should respect reversing and playbackRate");
+
+// Test zero iterationDuration.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    dt.play(createTestMediaReference(video, 0.0));
+    assert_equals(video.currentTime,  0.0);
+  });
+  at(1.0, function() {
+    assert_equals(video.currentTime,  0.0);
+  });
+}, "Video should start at time zero when iterationDuration is zero");
+
+// Test zero intrinsic iterationDuration.
+// TODO: Need to find a zero length video.
+
+// Test that media elements are removed from their MediaController.
+timing_test(function() {
+  var video = getNextVideo();
+  at(0.0, function() {
+    video.controller = new MediaController();
+    dt.play(createTestMediaReference(video));
+    assert_equals(video.controller,  null);
+  });
   // Seeking the video will throw if the controller has not been detached.
-  player.paused = true;
-  player.currentTime = 1.0;
-  raf(function() {
-    test(function() {assert_equals(video.currentTime,  1.0)},
-         "Detaching controller should allow video to be seeked");
-    player.source = null;
-    continuation18();
+  at(1.0, function() {
+    assert_equals(video.currentTime,  1.0);
   });
-};
+}, "Video should be detached from controller when used in MediaReference");
 
-var continuation18 = function() {
-  // Test limited seek ranges.
-  // TODO: Need to find a video with limited seek ranges.
-  finished();
-};
-
-var finished = function() {
-  animTestRunner.done();
-};
+// Test limited seek ranges.
+// TODO: Need to find a video with limited seek ranges.
 
 </script>

--- a/test/testcases/test-player.html
+++ b/test/testcases/test-player.html
@@ -21,12 +21,6 @@ Written by Steph McArthur
 
 <script src="../bootstrap.js" nochecks></script>
 <script>
-
-// Don't use a local named requestAnimationFrame, to avoid potential problems
-// with hoisting.
-var raf = window.requestAnimationFrame || window.webkitRequestAnimationFrame ||
-    window.mozRequestAnimationFrame || window.msRequestAnimationFrame;
-
 var animation = new Animation(document.getElementById("anim"), {left: "100px"});
 var dt = document.timeline;
 

--- a/web-animations.js
+++ b/web-animations.js
@@ -1410,6 +1410,10 @@ MediaReference.prototype = createObject(TimedItem.prototype, {
     return this._media === element;
   },
   _getAnimationsTargetingElement: function(element, animations) { },
+  _attach: function(player) {
+    this._ensurePaused();
+    TimedItem.prototype._attach.call(this, player);
+  },
 });
 
 


### PR DESCRIPTION
The test runs fine in Chrome, but seems flaky with run-tests.py - investigating
