### PR TITLE
Fixing Issue #313 - at doesn't handle NaN gracefully.

### DIFF
--- a/test/testharness_timing.js
+++ b/test/testharness_timing.js
@@ -602,6 +602,10 @@
         var at = function(seconds, f, desc_at)
         {
             assert_true(typeof seconds == "number", "at's first argument shoud be a number.");
+            assert_true(!isNaN(seconds), "at's first argument should be a number not NaN!");
+            assert_true(seconds >= 0, "at's first argument should be greater then 0.");
+            assert_true(isFinite(seconds), "at's first argument should be finite.");
+
             assert_true(typeof f == "function", "at's second argument should be a function.");
 
             // Deliberately hoist the desc if we where not given one.


### PR DESCRIPTION
Added more checks to the seconds argument for at(). Now makes sure;
- the number is positive or zero,
- the number isn't NaN,
- the number is finite.

See https://github.com/web-animations/web-animations-js/issues/313
