### PR TITLE
Make event handling asynchronous

### DIFF
--- a/test/testcases/manual-test-add-player-onend.html
+++ b/test/testcases/manual-test-add-player-onend.html
@@ -45,8 +45,6 @@ var element = document.querySelector('#target');
 var animation = new Animation(element, {left: '50px'}, 0.5);
 animation.addEventListener('end', function() {
   var nextAnimation = new Animation(element, {left: '100px'}, 0.5);
-  nextAnimation.addEventListener('start', function() {
-  });
   nextAnimation.addEventListener('end', function() {
     test.step(function() { assert_styles("#target", {left:'100px'}); });
     test.done();

--- a/test/testcases/manual-test-add-player-onend.html
+++ b/test/testcases/manual-test-add-player-onend.html
@@ -42,16 +42,13 @@ limitations under the License.
 
 var test = async_test('Check second animation has fired after being triggered inside onend callback');
 var element = document.querySelector('#target');
-var animation = new Animation(element, { left: '50px' }, 0.5);
+var animation = new Animation(element, {left: '50px'}, 0.5);
 animation.addEventListener('end', function() {
-  console.log('testpants');
-  var nextAnimation = new Animation(element, { left: '100px' }, 0.5);
+  var nextAnimation = new Animation(element, {left: '100px'}, 0.5);
   nextAnimation.addEventListener('start', function() {
-    console.log('testDuck');
   });
   nextAnimation.addEventListener('end', function() {
-    console.log('testChicken');
-    test.step(function() { assert_styles("#target", {'left':'100px'}); });
+    test.step(function() { assert_styles("#target", {left:'100px'}); });
     test.done();
   });
   document.timeline.play(nextAnimation);

--- a/test/testcases/manual-test-add-player-onend.html
+++ b/test/testcases/manual-test-add-player-onend.html
@@ -1,0 +1,62 @@
+<!--
+Copyright 2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html><meta charset="UTF-8">
+
+<style>
+#target {
+  background-color: lightsteelblue;
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  left: 0px;
+}
+#expected {
+  background-color: darkred;
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  left: 100px;
+}
+</style>
+
+<div id="expected"></div>
+<div id="target"></div>
+
+<script src="../bootstrap.js"></script>
+<script>
+'use strict';
+
+var test = async_test('Check second animation has fired after being triggered inside onend callback');
+var element = document.querySelector('#target');
+var animation = new Animation(element, { left: '50px' }, 0.5);
+animation.addEventListener('end', function() {
+  console.log('testpants');
+  var nextAnimation = new Animation(element, { left: '100px' }, 0.5);
+  nextAnimation.addEventListener('start', function() {
+    console.log('testDuck');
+  });
+  nextAnimation.addEventListener('end', function() {
+    console.log('testChicken');
+    test.step(function() { assert_styles("#target", {'left':'100px'}); });
+    test.done();
+  });
+  document.timeline.play(nextAnimation);
+});
+document.timeline.play(animation);
+
+timing_test(function() {at(1, function() {});}, 'Force testharness to execute to 1 second.');
+</script>

--- a/test/testcases/test-addeventlistener.html
+++ b/test/testcases/test-addeventlistener.html
@@ -29,7 +29,7 @@ limitations under the License.
 <script>
 'use strict';
 
-var effect = new KeyframeAnimationEffect([{ left: '100px' }]);
+var effect = { left: '100px' };
 
 var timingInput = {
   iterations: 2,
@@ -50,10 +50,12 @@ function createAnimation() {
   animation = createAnimation();
   var singleEventHandler = false;
   animation.addEventListener(eventType, function() { singleEventHandler = true; })
+  var testA = async_test('Check ' + eventType + ' event with single handler');
+  animation.addEventListener(eventType, function() {
+    testA.step(function() { assert_true(singleEventHandler); });
+    testA.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_true(singleEventHandler);
-  });}, 'Check ' + eventType + ' event with single handler');
 
 
   var animation = createAnimation();
@@ -61,10 +63,12 @@ function createAnimation() {
   var addMultipleTimes = function() { eventHandlingCount++; };
   animation.addEventListener(eventType, addMultipleTimes);
   animation.addEventListener(eventType, addMultipleTimes);
+  var testB = async_test('Check ' + eventType + ' event with single handler added multiple times');
+  animation.addEventListener(eventType, function() {
+    testB.step(function() { assert_equals(eventHandlingCount, 1); });
+    testB.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_equals(eventHandlingCount, 1);
-  });}, 'Check ' + eventType + ' event with single handler added multiple times');
 
 
   animation = createAnimation();
@@ -74,10 +78,12 @@ function createAnimation() {
   animation.addEventListener(eventType, function() { multiEventHandlerA = true; })
   animation.addEventListener(eventType, function() { multiEventHandlerB = true; })
   animation.addEventListener(eventType, function() { multiEventHandlerC = true; })
+  var testC = async_test('Check ' + eventType + ' event with multiple handlers');
+  animation.addEventListener(eventType, function() {
+    testC.step(function() { assert_true(multiEventHandlerA && multiEventHandlerB && multiEventHandlerC); });
+    testC.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_true(multiEventHandlerA && multiEventHandlerB && multiEventHandlerC);
-  });}, 'Check ' + eventType + ' event with multiple handlers');
 
 
   animation = createAnimation();
@@ -87,29 +93,35 @@ function createAnimation() {
   var eventHandlerToRemove = function() { removeEventHandler = false; }
   animation.addEventListener(eventType, eventHandlerToRemove);
   animation.removeEventListener(eventType, eventHandlerToRemove);
+  var testD = async_test('Check ' + eventType + ' event with event handler removed');
+  animation.addEventListener(eventType, function() {
+    testD.step(function() { assert_true(retainEventHandler && removeEventHandler); });
+    testD.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_true(retainEventHandler && removeEventHandler);
-  });}, 'Check ' + eventType + ' event with event handler removed');
 
 
   animation = createAnimation();
   var onEventHandler = false;
   animation['on' + eventType] = function() { onEventHandler = true; };
+  var testE = async_test('Check on' + eventType + ' handler');
+  animation.addEventListener(eventType, function() {
+    testE.step(function() { assert_true(onEventHandler); });
+    testE.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_true(onEventHandler);
-  });}, 'Check on' + eventType + ' handler');
 
 
   animation = createAnimation();
   var clearOnEventHandler = true;
   animation['on' + eventType] = function() { clearOnEventHandler = false; };
   animation['on' + eventType] = null;
+  var testF = async_test('Check clearing on' + eventType + ' handler');
+  animation.addEventListener(eventType, function() {
+    testF.step(function() { assert_true(clearOnEventHandler); });
+    testF.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_true(clearOnEventHandler);
-  });}, 'Check clearing on' + eventType + ' handler');
 
 
   animation = createAnimation();
@@ -119,10 +131,12 @@ function createAnimation() {
   animation.addEventListener(eventType, function() { onEventOrdering += 'b'; });
   animation['on' + eventType] = function() { onEventOrdering += 'c'; };
   animation.addEventListener(eventType, function() { onEventOrdering += 'd'; });
+  var testG = async_test('Check on' + eventType + ' handler ordering and overriding');
+  animation.addEventListener(eventType, function() {
+    testG.step(function() { assert_equals(onEventOrdering, 'abcd'); });
+    testG.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_equals(onEventOrdering, 'abcd');
-  });}, 'Check on' + eventType + ' handler ordering and overriding');
 
 
   animation = createAnimation();
@@ -136,10 +150,12 @@ function createAnimation() {
   animation.addEventListener(eventType, eventHandlerToRemoveB);
   animation.removeEventListener(eventType, eventHandlerToRemoveA);
   animation.removeEventListener(eventType, eventHandlerToRemoveB);
+  var testH = async_test('Check on' + eventType + ' handler ordering after removal');
+  animation.addEventListener(eventType, function() {
+    testH.step(function() { assert_equals(onEventOrderingAfterRemoval, 'abc'); });
+    testH.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_equals(onEventOrderingAfterRemoval, 'abc');
-  });}, 'Check on' + eventType + ' handler ordering after removal');
 
 
   animation = createAnimation();
@@ -147,9 +163,15 @@ function createAnimation() {
   var duplicateFunction = function() { onEventDuplication += 1; };
   animation.addEventListener(eventType, duplicateFunction);
   animation['on' + eventType] = duplicateFunction;
+  var testI = async_test('Check on' + eventType + ' handler duplication');
+  animation.addEventListener(eventType, function() {
+    testI.step(function() { assert_equals(onEventDuplication, 2); });
+    testI.done();
+  });
   document.timeline.play(animation);
-  timing_test(function() {at(1, function() {
-    assert_equals(onEventDuplication, 2);
-  });}, 'Check on' + eventType + ' handler duplication');
 });
+
+// This test at one second forces the automated test runner to simulate one second of execution.
+timing_test(function() {at(1.0, function () {});});
+
 </script>

--- a/test/testcases/test-addeventlistener.html
+++ b/test/testcases/test-addeventlistener.html
@@ -171,7 +171,6 @@ function createAnimation() {
   document.timeline.play(animation);
 });
 
-// This test at one second forces the automated test runner to simulate one second of execution.
-timing_test(function() {at(1.0, function () {});});
+timing_test(function(){at(1, function(){});}, 'Force testharness to execute to 1 second.');
 
 </script>

--- a/web-animations.js
+++ b/web-animations.js
@@ -821,19 +821,21 @@ TimedItem.prototype = {
         isDefinedAndNotNull(this._onHandlers[type]);
   },
   _callHandlers: function(type, event) {
-    var onIndex = -1;
+    var callbackList;
+    if (isDefinedAndNotNull(this._handlers[type])) {
+      callbackList = this._handlers[type].slice();
+    } else {
+      callbackList = [];
+    }
     if (isDefinedAndNotNull(this._onHandlers[type])) {
-      onIndex = this._onHandlers[type].index;
+      callbackList.splice(this._onHandlers[type].index, 0,
+          this._onHandlers[type].callback);
     }
-    var handlersLength = (this._handlers[type] || []).length;
-    for (var i = 0; i <= handlersLength; i++) {
-      if (onIndex === i) {
-        this._onHandlers[type].callback.call(this, event);
+    setTimeout(function() {
+      for (var i = 0; i < callbackList.length; i++) {
+        callbackList[i].call(this, event);
       }
-      if (i < handlersLength) {
-        this._handlers[type][i].call(this, event);
-      }
-    }
+    }, 0);
   },
   _generateChildEventsForRange: function() { },
   _toSubRanges: function(fromTime, toTime, iterationTimes) {


### PR DESCRIPTION
When players are played in the end event of the last player they do not get played.
Making the events fire asynchronously fixes the problem by allowing player registration to occur at the appropriate time.
