### PR TITLE
Fallback to non-mirrors version if the mirrors version fails.

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -49,4 +49,4 @@ Firefox)
 	;;
 esac
 
-pip install -r .requirements --use-mirrors
+pip install -r .requirements --use-mirrors || pip install -r .requirements


### PR DESCRIPTION
The mirror stuff seem to be a bit flaky on Travis at the moment, fall back to non-mirror if needed.
