### PR TITLE
Moving testharness_after_loaded to straight after testharness being loaded

### DIFF
--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1234,8 +1234,8 @@ window.testharness_after_loaded = function() {
 
 };
 
-
 loadScript('../testharness/testharness.js', {coverage: false});
+document.write('<script type="text/javascript">window.testharness_after_loaded();</script>');
 loadCSS('../testharness/testharness.css');
 loadCSS('../testharness_timing.css');
 
@@ -1271,7 +1271,5 @@ if (testType() != 'unit') {
   window.performance.now = null;
   window.Date.now = testharness_timeline.now.bind(testharness_timeline);
 }
-
-document.write('<script type="text/javascript">window.testharness_after_loaded();</script>');
 
 })();


### PR DESCRIPTION
The testharness_after_loaded code should run right after testharness.js is loaded and before web-animations is loaded. Not sure why this ever worked in the current state?
