### PR TITLE
returnValue should not be part of TimingEvent

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -959,7 +959,6 @@ var TimingEvent = function(token, target, type, localTime, timelineTime, iterati
   }
   this._target = target;
   this._type = type;
-  this.returnValue = true;
   this.localTime = localTime;
   this.timelineTime = timelineTime;
   this.iterationIndex = iterationIndex;


### PR DESCRIPTION
returnValue is part of BeforeUnloadEvent which TimingEvent does not inherit from.

This was causing issues with the ShadowDOM polyfill for Chrome since Chrome incorrectly puts returnValue on Event and the polyfill wraps that in an accessor pair which gets invoked by the assignment in the constructor.
