### PR TITLE
Two small fixes to run-tests code (for Firefox)

### DIFF
--- a/tools/python/run-tests.py
+++ b/tools/python/run-tests.py
@@ -624,7 +624,10 @@ try:
             if v:
                 break
 
-            status = browser.find_element_by_id('status-box').text.strip()
+            try:
+                status = browser.find_element_by_id('status-box').text.strip()
+            except selenium_exceptions.NoSuchElementException, e:
+                status = "Unknown"
             print "Still waiting tests to finish", repr(v), status
             sys.stdout.flush()
             time.sleep(1)

--- a/tools/python/setup.sh
+++ b/tools/python/setup.sh
@@ -43,7 +43,7 @@ source bin/activate
 pip install --no-download -r requirements.txt > /dev/null 2>&1
 if [ $? -ne 0 ]; then
   # Install dependencies
-  pip install -r requirements.txt
+  pip install -r requirements.txt --upgrade
   if [ $? -ne 0 ]; then
     cat <<EOF
 Unable to install the required dependencies. Please see error output above.


### PR DESCRIPTION
Latest Firefox needs the latest selenium, hence the --upgrade
Shouldn't die on missing status-box.
