### PR TITLE
For a TimedItem with infinte duration, the transformed time should should be equal to the directed time

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -642,7 +642,8 @@ TimedItem.prototype = {
         unscaledIterationTime);
     this._timeFraction =
         this.specified._timingFunction(this).scaleTime(this._timeFraction);
-    this._iterationTime = this._timeFraction * this.duration;
+    this._iterationTime = this.duration === Infinity ?
+        this._iterationTime : this._timeFraction * this.duration;
   },
   _updateTimeMarkers: function() {
     if (this.localTime === null) {


### PR DESCRIPTION
Currently, in order to calculate the transformed time from the directed time,
we divide by the duration to get the time fraction, apply the timing function,
then multiply the result by the duration. This means that if the duration is
infinity, the transformed time is always zero, so the TimedItem's effect or
children will not play.

For a group, this behavior is probably unexpected. Consider the following
example ...

document.timeline.play(new ParGroup([
  new Animation(foo, bar, {iterations: Infinity, duration: 2}),
  new Animation(foo, bar, {iterations: Infinity, duration: 3}),
]));

A reasonable expectation is that both animations will repeat indefinitely, but
currently, neither will play. Note that in this example, the
'iterations: Infinity' can't easily be moved to the ParGroup because the
animations have different durations.

Instead, if the duration is infinity, we should set the transformed time to the
directed time. This means that the children's inherited times will progress as
expected, so they will play.

Note that the time fraction will remain zero, so an Animation with infinite
duration will still not play.
