### PR TITLE
Attach lazy retick to getComputedStyle after inline style change

### DIFF
--- a/test/testcases/auto-test-inline-style-checks.js
+++ b/test/testcases/auto-test-inline-style-checks.js
@@ -5,11 +5,8 @@ timing_test(function() {
   at(0.5, function() {
     assert_styles("#target",{'left':'50px','backgroundColor':'rgb(176, 196, 222)'});
   });
-  at(1, function() {
-    assert_styles("#target",{'left':'100px','backgroundColor':'rgb(176, 196, 222)'});
-  });
   at(1.5, function() {
-    assert_styles("#target",{'left':'75px','backgroundColor':'rgb(176, 196, 222)'});
+    assert_styles("#target",{'left':'100px','backgroundColor':'rgb(176, 196, 222)'});
   });
   at(2, function() {
     assert_styles("#target",{'left':'50px','backgroundColor':'rgb(176, 196, 222)'});

--- a/test/testcases/auto-test-inline-style.html
+++ b/test/testcases/auto-test-inline-style.html
@@ -43,7 +43,7 @@ var expected_failures = {
 
 var target = document.querySelector('#target');
 
-document.timeline.play(new Animation(target, {left: '100px', composite: 'replace'}, {duration: 1, iterations: 2, direction: 'alternate'}));
+document.timeline.play(new Animation(target, {left: '100px', composite: 'add'}, {duration: 1, iterations: 2, direction: 'alternate'}));
 
 at(0.5, function() {
   assert_equals(0, target.style.length);
@@ -52,6 +52,7 @@ at(0.5, function() {
 
 testharness_timeline.schedule(function() {
   target.style.left = '50px';
+  assert_styles(target, {left: '150px'}, 'getComputedStyle() should return correct value after setting inline style.');
 }, 1000);
 
 at(1.5, function() {

--- a/web-animations.js
+++ b/web-animations.js
@@ -4779,7 +4779,7 @@ AnimatedCSSStyleDeclaration.prototype = {
             this._surrogateElement.style.getPropertyValue(property));
       }
     }
-    repeatLastTick();
+    this._inlineStyleChanged();
   },
   get length() {
     return this._surrogateElement.style.length;
@@ -4819,6 +4819,16 @@ AnimatedCSSStyleDeclaration.prototype = {
   _setAnimatedProperty: function(property, value) {
     this._style[property] = value;
     this._isAnimatedProperty[property] = true;
+  },
+  _inlineStyleChanged: function() {
+    maybeRestartAnimation();
+    // Changing the inline style of an element under animation may require the
+    // animation to be recomputed ontop of the new inline style if
+    // getComputedStyle() is called inbetween setting the style and the next
+    // animation frame.
+    // We modify getComputedStyle() to re-evaluate the animations only if it is
+    // called instead of re-evaluating them here potentially unnecessarily.
+    ensureGetComputedStyleAugmented();
   }
 };
 
@@ -4848,11 +4858,35 @@ for (var property in document.documentElement.style) {
             if (!this._isAnimatedProperty[property]) {
               this._style[property] = value;
             }
-            repeatLastTick();
+            this._inlineStyleChanged();
           }
         }));
   })(property);
 }
+
+var retickThenGetComputedStyle = function() {
+  repeatLastTick();
+  // ticker() will restore getComputedStyle() back to normal.
+  return window.getComputedStyle.apply(this, arguments);
+};
+
+var originalGetComputedStyle = window.getComputedStyle;
+
+var ensureGetComputedStyleAugmented = function() {
+  if (window.getComputedStyle !== retickThenGetComputedStyle) {
+    Object.defineProperty(window, 'getComputedStyle', configureDescriptor({
+      value: retickThenGetComputedStyle
+    }));
+  }
+};
+
+var ensureGetComputedStyleRestored = function() {
+  if (window.getComputedStyle === retickThenGetComputedStyle) {
+    Object.defineProperty(window, 'getComputedStyle', configureDescriptor({
+      value: originalGetComputedStyle
+    }));
+  }
+};
 
 
 
@@ -5128,6 +5162,9 @@ var ticker = function(rafTime, isRepeat) {
     lastTickTime = rafTime;
     cachedClockTimeMillis = rafTime;
   }
+
+  // Clear any modifications to getComputedStyle.
+  ensureGetComputedStyleRestored();
 
   // Get animations for this sample. We order by Player then by DFS order within
   // each Player's tree.

--- a/web-animations.js
+++ b/web-animations.js
@@ -4828,7 +4828,7 @@ AnimatedCSSStyleDeclaration.prototype = {
     // animation frame.
     // We modify getComputedStyle() to re-evaluate the animations only if it is
     // called instead of re-evaluating them here potentially unnecessarily.
-    ensureGetComputedStyleAugmented();
+    ensureRetickBeforeGetComputedStyle();
   }
 };
 
@@ -4872,7 +4872,7 @@ var retickThenGetComputedStyle = function() {
 
 var originalGetComputedStyle = window.getComputedStyle;
 
-var ensureGetComputedStyleAugmented = function() {
+var ensureRetickBeforeGetComputedStyle = function() {
   if (window.getComputedStyle !== retickThenGetComputedStyle) {
     Object.defineProperty(window, 'getComputedStyle', configureDescriptor({
       value: retickThenGetComputedStyle
@@ -4880,7 +4880,7 @@ var ensureGetComputedStyleAugmented = function() {
   }
 };
 
-var ensureGetComputedStyleRestored = function() {
+var ensureOriginalGetComputedStyle = function() {
   if (window.getComputedStyle === retickThenGetComputedStyle) {
     Object.defineProperty(window, 'getComputedStyle', configureDescriptor({
       value: originalGetComputedStyle
@@ -5164,7 +5164,7 @@ var ticker = function(rafTime, isRepeat) {
   }
 
   // Clear any modifications to getComputedStyle.
-  ensureGetComputedStyleRestored();
+  ensureOriginalGetComputedStyle();
 
   // Get animations for this sample. We order by Player then by DFS order within
   // each Player's tree.


### PR DESCRIPTION
Setting the inline style of an animated element causes the animation frame to completely re-evaluate so that getComputedStyle() can be accurate with respect to the new inline style and any animations ontop of it.

Users that set hundreds of inline styles per frame without calling getComputedStyle are punished with a useless animation tick after each set. This change fixes that.
