### PR TITLE
Update auto-test-initial expectations for outline-color

### DIFF
--- a/test/testcases/auto-test-initial-checks.js
+++ b/test/testcases/auto-test-initial-checks.js
@@ -12,7 +12,7 @@ timing_test(function() {
     assert_styles("#opacity",{'opacity':'1'});
   }, "#opacity");
   at(0, function() {
-    assert_styles("#outline",{'outlineColor':'rgba(0, 0, 0, 0)','outlineWidth':'3px','outlineOffset':'0px'});
+    assert_styles("#outline",{'outlineWidth':'3px','outlineOffset':'0px'});
   }, "#outline");
   at(0, function() {
     assert_styles("#padding",{'paddingBottom':'0px','paddingLeft':'0px','paddingRight':'0px','paddingTop':'0px'});

--- a/test/testcases/auto-test-initial.html
+++ b/test/testcases/auto-test-initial.html
@@ -59,14 +59,9 @@ word word word word</pre>
 
 <script>
 var expected_failures = {
-  '#outline at t=0s' : {
-    chrome: ["28.0", "29.0"],
-    msie: true,
-    message: "Output changes from rgb to rgba in later Chrome, rbga(0, 0, 0, 0) gets converted to 'transparent' in IE."
-  },
-  '/(#background|#outline) at t=0s/' : {
+  '/(#background) at t=0s/' : {
     firefox: true,
-    message: "rbga(0, 0, 0, 0) gets converted to 'transparent' in Firefox."
+    message: "rgb(0, 0, 0) gets converted to 'transparent' in Firefox."
   },
   '#background at t=1s' : {
     firefox: true,


### PR DESCRIPTION
The expectations for this recently changed on Chrome unstable.
The check should be removed entirely as the value is spec'd to be user agent defined.
