### PR TITLE
Add inline style hack fallback (fixes Safari)

### DIFF
--- a/test/testcases.js
+++ b/test/testcases.js
@@ -12,6 +12,7 @@ var tests = [
   'auto-test-font-weight.html',
   'auto-test-initial.html',
   'auto-test-inline-style.html',
+  'auto-test-inline-style-fallback.html',
   'auto-test-inline-style-methods.html',
   'auto-test-integer.html',
   'auto-test-iteration-start.html',

--- a/test/testcases/auto-test-inline-style-fallback-checks.js
+++ b/test/testcases/auto-test-inline-style-fallback-checks.js
@@ -1,0 +1,17 @@
+timing_test(function() {
+  at(0, function() {
+    assert_styles("#target",{'left':'0px','backgroundColor':'rgb(176, 196, 222)'});
+  });
+  at(0.5, function() {
+    assert_styles("#target",{'left':'50px','backgroundColor':'rgb(176, 196, 222)'});
+  });
+  at(1.5, function() {
+    assert_styles("#target",{'left':'100px','backgroundColor':'rgb(176, 196, 222)'});
+  });
+  at(2, function() {
+    assert_styles("#target",{'left':'50px','backgroundColor':'rgb(176, 196, 222)'});
+  });
+  at(3, function() {
+    assert_styles("#target",{'left':'100px','backgroundColor':'rgb(0, 128, 0)'});
+  });
+}, "Auto generated tests");

--- a/test/testcases/auto-test-inline-style-fallback.html
+++ b/test/testcases/auto-test-inline-style-fallback.html
@@ -1,0 +1,84 @@
+<!--
+Copyright 2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!doctype html>
+<style>
+#target {
+  background-color: lightsteelblue;
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  left: 0px;
+}
+
+#spacer {
+  height: 100px;
+}
+</style>
+
+
+<div id="target"></div>
+<div id="spacer"></div>
+
+<script>
+var expected_failures = {
+};
+</script>
+<script src="../bootstrap.js"></script>
+<script>
+'use strict';
+
+var target = document.querySelector('#target');
+
+// Ensure the target cannot be monkey patched with a different style object.
+// This simulates Safari's behaviour in other browsers.
+try {
+  var originalStyle = target.style;
+  Object.defineProperty(target, 'style', {
+    get: function () {return originalStyle;},
+    configurable: false,
+  });
+} catch (_) {}
+
+
+document.timeline.play(new Animation(target, {left: '100px', composite: 'add'}, {duration: 1, iterations: 2, direction: 'alternate'}));
+
+at(0.5, function() {
+  assert_equals(target.style.length, 0);
+  assert_in_array(target.style.getPropertyValue('left'), ['', null]);
+});
+
+testharness_timeline.schedule(function() {
+  target.style.setProperty('left' , '50px');
+  assert_styles(target, {left: '150px'}, 'getComputedStyle() should return correct value after setting inline style.');
+}, 1000);
+
+at(1.5, function() {
+  assert_equals(target.style.length, 1);
+  assert_equals(target.style.getPropertyValue('left'), '50px');
+});
+
+testharness_timeline.schedule(function() {
+  target.style.cssText = 'left: 100px; background-color: green;';
+}, 2500);
+
+at(3, function() {
+  assert_equals(target.style.length, 2);
+  assert_equals(target.style.getPropertyValue('left'), '100px');
+  assert_equals(target.style.getPropertyValue('background-color'), 'green');
+});
+
+</script>

--- a/test/testcases/auto-test-inline-style-fallback.html
+++ b/test/testcases/auto-test-inline-style-fallback.html
@@ -57,7 +57,6 @@ try {
 document.timeline.play(new Animation(target, {left: '100px', composite: 'add'}, {duration: 1, iterations: 2, direction: 'alternate'}));
 
 at(0.5, function() {
-  assert_equals(target.style.length, 0);
   assert_in_array(target.style.getPropertyValue('left'), ['', null]);
 });
 
@@ -67,16 +66,15 @@ testharness_timeline.schedule(function() {
 }, 1000);
 
 at(1.5, function() {
-  assert_equals(target.style.length, 1);
   assert_equals(target.style.getPropertyValue('left'), '50px');
 });
 
 testharness_timeline.schedule(function() {
-  target.style.cssText = 'left: 100px; background-color: green;';
+  target.style.setProperty('left', '100px');
+  target.style.setProperty('background-color', 'green');
 }, 2500);
 
 at(3, function() {
-  assert_equals(target.style.length, 2);
   assert_equals(target.style.getPropertyValue('left'), '100px');
   assert_equals(target.style.getPropertyValue('background-color'), 'green');
 });

--- a/web-animations.js
+++ b/web-animations.js
@@ -4769,20 +4769,24 @@ var retickThenGetComputedStyle = function() {
 };
 
 var originalGetComputedStyle = window.getComputedStyle;
+// This redundant flag is to support Safari which has trouble determining function object equality during an animation.
+var isGetComputedStylePatched = false;
 
 var ensureRetickBeforeGetComputedStyle = function() {
-  if (window.getComputedStyle !== retickThenGetComputedStyle) {
+  if (window.getComputedStyle !== retickThenGetComputedStyle || !isGetComputedStylePatched) {
     Object.defineProperty(window, 'getComputedStyle', configureDescriptor({
       value: retickThenGetComputedStyle
     }));
+    isGetComputedStylePatched = true;
   }
 };
 
 var ensureOriginalGetComputedStyle = function() {
-  if (window.getComputedStyle === retickThenGetComputedStyle) {
+  if (window.getComputedStyle !== originalGetComputedStyle || isGetComputedStylePatched) {
     Object.defineProperty(window, 'getComputedStyle', configureDescriptor({
       value: originalGetComputedStyle
     }));
+    isGetComputedStylePatched = false;
   }
 };
 

--- a/web-animations.js
+++ b/web-animations.js
@@ -5060,8 +5060,7 @@ var ensureTargetCSSInitialised = function(target) {
     Object.defineProperty(target, 'style', configureDescriptor({
       get: function() { return animatedStyle; }
     }));
-  }
-  catch (error) {
+  } catch (error) {
     patchInlineStyleForAnimation(target.style);
   }
   target.style._webAnimationsStyleInitialised = true;

--- a/web-animations.js
+++ b/web-animations.js
@@ -4936,6 +4936,7 @@ for (var property in document.documentElement.style) {
 var patchInlineStyleForAnimation = function(style) {
   var surrogateElement = document.createElement('div');
   copyInlineStyle(style, surrogateElement.style);
+  var isAnimatedProperty = {};
   for (var method in cssStyleDeclarationMethodModifiesStyle) {
     if (!(method in style)) {
       continue;
@@ -4943,12 +4944,15 @@ var patchInlineStyleForAnimation = function(style) {
     Object.defineProperty(style, method, configureDescriptor({
       value: (function(method, originalMethod, modifiesStyle) {
         return function() {
-          if (modifiesStyle) {
-            animatedInlineStyleChanged();
-            originalMethod.apply(style, arguments);
-          }
-          return surrogateElement.style[method].apply(
+          var result = surrogateElement.style[method].apply(
               surrogateElement.style, arguments);
+          if (modifiesStyle) {
+            if (!isAnimatedProperty[arguments[0]]) {
+              originalMethod.apply(style, arguments);
+            }
+            animatedInlineStyleChanged();
+          }
+          return result;
         }
       })(method, style[method], cssStyleDeclarationMethodModifiesStyle[method])
     }));
@@ -4956,10 +4960,12 @@ var patchInlineStyleForAnimation = function(style) {
 
   style._clearAnimatedProperty = function(property) {
     this[property] = surrogateElement.style[property];
+    isAnimatedProperty[property] = false;
   };
 
   style._setAnimatedProperty = function(property, value) {
     this[property] = value;
+    isAnimatedProperty[property] = true;
   };
 };
 

--- a/web-animations.js
+++ b/web-animations.js
@@ -4948,55 +4948,63 @@ Compositor.prototype = {
 
 var ensureTargetInitialised = function(property, target) {
   if (propertyIsSVGAttrib(property, target)) {
-    if (!isDefinedAndNotNull(target._actuals)) {
-      target._actuals = {};
-      target._bases = {};
-      target.actuals = {};
-      target._getAttribute = target.getAttribute;
-      target._setAttribute = target.setAttribute;
-      target.getAttribute = function(name) {
-        if (isDefinedAndNotNull(target._bases[name])) {
-          return target._bases[name];
-        }
-        return target._getAttribute(name);
-      };
-      target.setAttribute = function(name, value) {
-        if (isDefinedAndNotNull(target._actuals[name])) {
-          target._bases[name] = value;
-        } else {
-          target._setAttribute(name, value);
-        }
-      };
-    }
-    if (!isDefinedAndNotNull(target._actuals[property])) {
-      var baseVal = target.getAttribute(property);
-      target._actuals[property] = 0;
-      target._bases[property] = baseVal;
-
-      Object.defineProperty(target.actuals, property, configureDescriptor({
-        set: function(value) {
-          if (value === null) {
-            target._actuals[property] = target._bases[property];
-            target._setAttribute(property, target._bases[property]);
-          } else {
-            target._actuals[property] = value;
-            target._setAttribute(property, value);
-          }
-        },
-        get: function() {
-          return target._actuals[property];
-        }
-      }));
-    }
+    ensureTargetSVGInitialised(property, target);
   } else {
-    if (target.style instanceof AnimatedCSSStyleDeclaration) {
-      return;
-    }
-    var animatedStyle = new AnimatedCSSStyleDeclaration(target);
-    Object.defineProperty(target, 'style', configureDescriptor({
-      get: function() { return animatedStyle; }
+    ensureTargetCSSInitialised(target);
+  }
+};
+
+var ensureTargetSVGInitialised = function(property, target) {
+  if (!isDefinedAndNotNull(target._actuals)) {
+    target._actuals = {};
+    target._bases = {};
+    target.actuals = {};
+    target._getAttribute = target.getAttribute;
+    target._setAttribute = target.setAttribute;
+    target.getAttribute = function(name) {
+      if (isDefinedAndNotNull(target._bases[name])) {
+        return target._bases[name];
+      }
+      return target._getAttribute(name);
+    };
+    target.setAttribute = function(name, value) {
+      if (isDefinedAndNotNull(target._actuals[name])) {
+        target._bases[name] = value;
+      } else {
+        target._setAttribute(name, value);
+      }
+    };
+  }
+  if (!isDefinedAndNotNull(target._actuals[property])) {
+    var baseVal = target.getAttribute(property);
+    target._actuals[property] = 0;
+    target._bases[property] = baseVal;
+
+    Object.defineProperty(target.actuals, property, configureDescriptor({
+      set: function(value) {
+        if (value === null) {
+          target._actuals[property] = target._bases[property];
+          target._setAttribute(property, target._bases[property]);
+        } else {
+          target._actuals[property] = value;
+          target._setAttribute(property, value);
+        }
+      },
+      get: function() {
+        return target._actuals[property];
+      }
     }));
   }
+};
+
+var ensureTargetCSSInitialised = function(target) {
+  if (target.style instanceof AnimatedCSSStyleDeclaration) {
+    return;
+  }
+  var animatedStyle = new AnimatedCSSStyleDeclaration(target);
+  Object.defineProperty(target, 'style', configureDescriptor({
+    get: function() { return animatedStyle; }
+  }));
 };
 
 var setValue = function(target, property, value) {

--- a/web-animations.js
+++ b/web-animations.js
@@ -4768,12 +4768,13 @@ var retickThenGetComputedStyle = function() {
   return window.getComputedStyle.apply(this, arguments);
 };
 
-var originalGetComputedStyle = window.getComputedStyle;
-// This redundant flag is to support Safari which has trouble determining function object equality during an animation.
+// This redundant flag is to support Safari which has trouble determining
+// function object equality during an animation.
 var isGetComputedStylePatched = false;
+var originalGetComputedStyle = window.getComputedStyle;
 
 var ensureRetickBeforeGetComputedStyle = function() {
-  if (window.getComputedStyle !== retickThenGetComputedStyle || !isGetComputedStylePatched) {
+  if (!isGetComputedStylePatched) {
     Object.defineProperty(window, 'getComputedStyle', configureDescriptor({
       value: retickThenGetComputedStyle
     }));
@@ -4782,7 +4783,7 @@ var ensureRetickBeforeGetComputedStyle = function() {
 };
 
 var ensureOriginalGetComputedStyle = function() {
-  if (window.getComputedStyle !== originalGetComputedStyle || isGetComputedStylePatched) {
+  if (isGetComputedStylePatched) {
     Object.defineProperty(window, 'getComputedStyle', configureDescriptor({
       value: originalGetComputedStyle
     }));


### PR DESCRIPTION
This change provides an alternate patch for animated inline styles.
If replacing element.style with an AnimatedCSSStyleDeclaration is not allowed (which is the case for Safari) it will instead patch the existing inline style object methods to behave in a similar way.
Property getters and setters are not patched and will not function normally while under animation with this fallback.

Fixes #492 
