### PR TITLE
Fixed generation of start events for delayed animations

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -416,7 +416,7 @@ Player.prototype = {
   },
   _generateEvents: function() {
     if (!isDefinedAndNotNull(this._lastCurrentTime)) {
-      this._lastCurrentTime = this._startTime;
+      this._lastCurrentTime = 0;
     }
 
     if (this._needsHandlerPass) {


### PR DESCRIPTION
Manual testcase (note use of setTimeout which is problematic in our own test suite):

```
<!doctype html>
<html>
    <head>
      <script src="web-animations.js"></script>
        <style>
            #target {
                background-color: orange;
                width: 150px;
                height: 150px;
            }
        </style>
    </head>
    <body>
        <div id="target">
            <button onclick="animateOne()">animate</button>
        </div>
        <div id="result"></div>
        <script>
            function startFn(e) {
                console.log('start', e.target);
            };
            function iterationFn(e) {
                console.log('iteration', e.target);
            };
            function endFn(e) {
                console.log('end', e.target);
            };

            function attachEvents(a) {
                a.oniteration = iterationFn;
                a.onend = endFn;
                a.onstart = startFn;
            };

            function animateOne(startdelay) {
                var anim = new Animation(target, [
                    {width: "150px"},
                    {width: "300px"}
                ], {duration: 1, delay: startdelay || 0});
                attachEvents(anim);
                setTimeout(function() {
                    document.timeline.play(anim);
                }, 1000);
            };
        </script>
    </body>
</html>
```
