### PR TITLE
Create cache buster at test-runner level and pass it down.

### DIFF
--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -77,8 +77,8 @@ function loadScript(src, options) {
     instrument(src);
     loadScript(src);
   } else {
-    if (!in_explore_mode()) {
-      src += '?' + window.Date.now();
+    if (!inExploreMode()) {
+      src += '?' + getCacheBuster();
     }
     document.write('<script type="text/javascript" src="'+ src + '"></script>');
   }
@@ -106,6 +106,21 @@ function testType() {
 
   var match = /(auto|impl|manual|unit)-test[^\\\/]*$/.exec(p);
   return match ? match[1]: 'unknown';
+}
+
+function inExploreMode() {
+  return '#explore' == window.location.hash || window.location.hash.length == 0;
+}
+
+/**
+ * Get a value for busting the cache. If we got given a cache buster, pass it
+ * along, otherwise generate a new one.
+ */
+var cacheBusterValue = '' + window.Date.now();
+function getCacheBuster() {
+  if (window.location.search.length > 0)
+    cacheBusterValue = window.location.search.substr(1, window.location.search.length);
+  return cacheBusterValue;
 }
 
 var instrumentationDepsLoaded = false;
@@ -1100,11 +1115,6 @@ TestTimeline.prototype.autorun = function() {
   this.toNextEvent();
 };
 
-
-function in_explore_mode() {
-  return '#explore' == window.location.hash || window.location.hash.length == 0;
-}
-
 function testharness_timeline_setup() {
   log('testharness_timeline_setup');
   testharness_timeline.createGUI(document.getElementsByTagName('body')[0]);
@@ -1128,8 +1138,7 @@ function testharness_timeline_setup() {
     // Need non-zero timeout to allow chrome to run other code.
     setTimeout(testharness_timeline.autorun.bind(testharness_timeline), 1);
 
-  } else if (in_explore_mode()) {
-
+  } else if (inExploreMode()) {
     setTimeout(testharness_timeline.runner_.start.bind(testharness_timeline.runner_), 1);
   } else {
     alert('Unknown start mode.');

--- a/test/test-runner.html
+++ b/test/test-runner.html
@@ -164,6 +164,10 @@ function trueOffsetTop(element) {
   }
 }
 
+/**
+ * Get a value for busting the cache.
+ */
+var cacheBuster = '' + window.Date.now();
 
 /**
  * Get the most accurate version of time possible.
@@ -190,9 +194,6 @@ function now() {
  * @return {Element} tbody containing newly created table rows.
  */
 function createTestRows(testName, testURL) {
-  // Prevent caching of the test file.
-  testURL += '?' + Date.now();
-
   var tableGroup = document.createElement('tbody');
   tableGroup.id = testName.replace('.', '-');
 
@@ -233,7 +234,7 @@ function createTestRows(testName, testURL) {
 
   // iframe containing a preview of object
   var iframe = document.createElement('iframe');
-  iframe.src = testURL + '#message';
+  iframe.src = testURL + '?' + cacheBuster + '#message';
 
   var iframeCell = document.createElement('td');
   iframeCell.colSpan = '4';


### PR DESCRIPTION
This means that 100 unique copies of web-animation.js (and similar files) are
not loaded when running inside the test-runner (a big performance problem for
Android).
