### PR TITLE
Match spec's definition of the active phase for a timed item

### DIFF
--- a/test/testcases/test-getcurrent.html
+++ b/test/testcases/test-getcurrent.html
@@ -138,12 +138,10 @@ timing_test(function () {
       var timelinePlayers = document.timeline.getCurrentPlayers();
       var aPlayers = a.getCurrentPlayers();
       var bPlayers = b.getCurrentPlayers();
-      assert_equals(timelinePlayers.length, 3, "timelinePlayers count");
-      assert_in_array(playerA, timelinePlayers, "timelinePlayers contains playerA");
+      assert_equals(timelinePlayers.length, 2, "timelinePlayers count");
       assert_in_array(playerB, timelinePlayers, "timelinePlayers contains playerB");
       assert_in_array(playerAB, timelinePlayers, "timelinePlayers contains playerAB");
-      assert_equals(aPlayers.length, 2, "Players on A length");
-      assert_in_array(playerA, aPlayers, "Players on A contains playerA");
+      assert_equals(aPlayers.length, 1, "Players on A length");
       assert_in_array(playerAB, aPlayers, "Players on A contains playerAB");
       assert_equals(bPlayers.length, 2, "Players on B length");
       assert_in_array(playerB, bPlayers, "Players on B contains playerB");
@@ -170,13 +168,11 @@ timing_test(function () {
       var timelinePlayers = document.timeline.getCurrentPlayers();
       var aPlayers = a.getCurrentPlayers();
       var bPlayers = b.getCurrentPlayers();
-      assert_equals(timelinePlayers.length, 2, "timelinePlayers count");
-      assert_in_array(playerB, timelinePlayers, "timelinePlayers contains playerB");
+      assert_equals(timelinePlayers.length, 1, "timelinePlayers count");
       assert_in_array(playerAB, timelinePlayers, "timelinePlayers contains playerAB");
       assert_equals(aPlayers.length, 1, "Players on A length");
       assert_in_array(playerAB, aPlayers, "Players on A contains playerAB");
-      assert_equals(bPlayers.length, 2, "Players on B length");
-      assert_in_array(playerB, bPlayers, "Players on B contains playerB");
+      assert_equals(bPlayers.length, 1, "Players on B length");
       assert_in_array(playerAB, bPlayers, "Players on B contains playerAB");
     });
   }, "Check current players at t=12");
@@ -198,12 +194,9 @@ timing_test(function () {
       var timelinePlayers = document.timeline.getCurrentPlayers();
       var aPlayers = a.getCurrentPlayers();
       var bPlayers = b.getCurrentPlayers();
-      assert_equals(timelinePlayers.length, 1, "timelinePlayers count");
-      assert_in_array(playerAB, timelinePlayers, "timelinePlayers contains playerAB");
-      assert_equals(aPlayers.length, 1, "Players on A length");
-      assert_in_array(playerAB, aPlayers, "Players on A contains playerAB");
-      assert_equals(bPlayers.length, 1, "Players on B length");
-      assert_in_array(playerAB, bPlayers, "Players on B contains playerAB");
+      assert_equals(timelinePlayers.length, 0, "timelinePlayers count");
+      assert_equals(aPlayers.length, 0, "Players on A length");
+      assert_equals(bPlayers.length, 0, "Players on B length");
     });
   }, "Check current players at t=13");
 timing_test(function () {
@@ -273,8 +266,7 @@ timing_test(function () {
     at(11.0, function() {
       var aAnimations = a.getCurrentAnimations();
       var bAnimations = b.getCurrentAnimations();
-      assert_equals(aAnimations.length, 2, "Animations on A count");
-      assert_in_array(animationA, aAnimations, "Animations on A contains animationA");
+      assert_equals(aAnimations.length, 1, "Animations on A count");
       assert_in_array(animationAClone, aAnimations, "Animations on A contains animationAClone");
       assert_equals(bAnimations.length, 2, "Animations on B count");
       assert_in_array(animationB, bAnimations, "Animations on B contains animationB");
@@ -298,8 +290,7 @@ timing_test(function () {
       var bAnimations = b.getCurrentAnimations();
       assert_equals(aAnimations.length, 1, "Animations on A count");
       assert_in_array(animationAClone, aAnimations, "Animations on A contains animationAClone");
-      assert_equals(bAnimations.length, 2, "Animations on B count");
-      assert_in_array(animationB, bAnimations, "Animations on B contains animationB");
+      assert_equals(bAnimations.length, 1, "Animations on B count");
       assert_in_array(animationBClone, bAnimations, "Animations on B contains animationBClone");
     });
   }, "Check current animations at t=12");
@@ -317,10 +308,8 @@ timing_test(function () {
     at(13.0, function() {
       var aAnimations = a.getCurrentAnimations();
       var bAnimations = b.getCurrentAnimations();
-      assert_equals(aAnimations.length, 1, "Animations on A count");
-      assert_in_array(animationAClone, aAnimations, "Animations on A contains animationAClone");
-      assert_equals(bAnimations.length, 1, "Animations on B count");
-      assert_in_array(animationBClone, bAnimations, "Animations on B contains animationBClone");
+      assert_equals(aAnimations.length, 0, "Animations on A count");
+      assert_equals(bAnimations.length, 0, "Animations on B count");
     });
   }, "Check current animations at t=13");
 timing_test(function () {

--- a/web-animations.js
+++ b/web-animations.js
@@ -768,7 +768,7 @@ TimedItem.prototype = {
   },
   _getLeafItemsInEffectImpl: abstractMethod,
   _isPastEndOfActiveInterval: function() {
-    return this._inheritedTime > this.endTime;
+    return this._inheritedTime >= this.endTime;
   },
   get player() {
     return this.parent === null ?


### PR DESCRIPTION
Spec text:
A timed item is in the after phase if the timed item's local time is not null and is greater than or equal to the sum of its start delay and active duration.

http://dev.w3.org/fxtf/web-animations/#timed-item-phases-and-states
