### PR TITLE
Remove Python dependency on testtools in Travis

### DIFF
--- a/tools/python/requirements.txt
+++ b/tools/python/requirements.txt
@@ -1,4 +1,3 @@
-testtools>=0.9.30
 python-subunit # subunit
 selenium
 


### PR DESCRIPTION
All the Travis builds stopped working yesterday due to a setup step requiring input.
Removing the offending Python dependency fixes the problem and still yields running tests.

Example Travis build log from https://travis-ci.org/web-animations/web-animations-js/builds/18178877

```
+ pip install -r tools/python/requirements.txt --use-mirrors
Downloading/unpacking testtools>=0.9.30 (from -r tools/python/requirements.txt (line 1))
User for c.pypi.python.org: 
No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.
The build has been terminated
```
