### PR TITLE
Update Firefox 28 failure expectations for path test

### DIFF
--- a/test/testcases/auto-test-path.html
+++ b/test/testcases/auto-test-path.html
@@ -83,27 +83,42 @@ height: 600px;
 
 <script>
 var expected_failures = {
+  // Firefox
   '/#anim1/': {
     firefox: true,
     msie: true,
     message: "Doesn't quite follow path correctly."
   },
-  '/#anim2 at t=(0|1|2|7|8|10|11)s/': {
+  '/#anim2 at t=(0|1|2|10|11)s/': {
     firefox: true,
+    message: "Doesn't quite follow path correctly."
+  },
+  '/#anim2 at t=(7|8)s/': {
+    firefox: ['26.0', '27.0'],
     message: "Doesn't quite follow path correctly."
   },
   '/#anim3 at t=(0|7|8|10)s/': {
     firefox: true,
     message: "Doesn't quite follow path correctly."
   },
-  '/#anim3 at t=(0|6|7|8|10)s/': {
-    firefox: true,
+  '/#anim3 at t=6s/': {
+    firefox: ['26.0', '27.0'],
+    message: "Doesn't quite follow path correctly."
+  },
+  '/#anim3 at t=5s/': {
+    firefox: ['28.0'],
     message: "Doesn't quite follow path correctly."
   },
   '/#anim4 at t=(0|10)s/': {
     firefox: true,
     message: "Doesn't quite follow path correctly."
   },
+  '/#anim4 at t=(3|8|9)s/': {
+    firefox: ['28.0'],
+    message: "Doesn't quite follow path correctly."
+  },
+
+  // Internet Explorer
   '/#anim2 at t=(0|1|2|3|4|9|10|11)s/': {
     msie: true,
     message: "Doesn't quite follow path correctly."
@@ -116,6 +131,8 @@ var expected_failures = {
     msie: true,
     message: "Doesn't quite follow path correctly."
   },
+
+  // Android Chrome
   '/#anim3 at t=(7|8)s/' : {
     android: true,
     message: "Android uses integer SVG implementation."
@@ -124,9 +141,12 @@ var expected_failures = {
     android: true,
     message: "Android uses integer SVG implementation."
   },
+
+  // Firefox & Android Chrome
   '/#anim2 at t=9s/' : {
+    firefox: ['28.0'],
     android: true,
-    message: "Android uses integer SVG implementation."
+    message: "Firefox is non-visibly different and Android uses an integer SVG implementation."
   },
 };
 </script>


### PR DESCRIPTION
Firefox 28 is still visually correct, the numbers are just a bit different to Chrome.
