### PR TITLE
Apply animation effects as soon as an animation is played

### DIFF
--- a/test/testcases/test-update-state.html
+++ b/test/testcases/test-update-state.html
@@ -34,8 +34,20 @@ var expected_failures = {
 var element = document.createElement('span');
 document.body.appendChild(element);
 
-var anim = element.animate([{left: '0px'}, {left: '1000px'}], 10);
+test(function() {
+  element.animate([{marginLeft: '1px'}, {marginLeft: '1px'}], 1);
+  assert_styles(element, {marginLeft: '0px'});
+}, 'New animation should not apply within script before timeline has started.')
+
 timing_test(function() {
+  at(0, function() {
+    element.animate([{marginTop: '1px'}, {marginTop: '1px'}], 1);
+    assert_styles(element, {marginTop: '1px'});
+  });
+}, 'New animation should apply within script after timeline has started.')
+
+timing_test(function() {
+  var anim = element.animate([{left: '0px'}, {left: '1000px'}], 10);
   at(1, function() {
     assert_styles(element, {left: '100px'});
 
@@ -44,12 +56,12 @@ timing_test(function() {
   });
 }, 'Updated style should be visible after player seek');
 
-var anim2 = element.animate([{top: '0px'}, {top: '1000px'}], 10);
 timing_test(function() {
+  var anim = element.animate([{top: '0px'}, {top: '1000px'}], 10);
   at(1, function() {
     assert_styles(element, {top: '100px'});
 
-    anim2.specified.delay = -1;
+    anim.specified.delay = -1;
     assert_styles(element, {top: '200px'});
   });
 }, 'Updated style should be visible after change to specified timing');
@@ -74,12 +86,8 @@ timing_test(function() {
 timing_test(function() {
   at(3, function() {
     var anim = element.animate([{color: 'red'}, {color: 'green'}, {color: 'red'}], 1);
-    // TODO: Really this should already be in effect, since the start
-    //       time == lastTick. But if that is fixed it's unclear how
-    //       to start an animation after the last tick (in this
-    //       harness).
     assert_equals(anim.player.startTime, 3);
-    assert_styles(element, {color: 'inherit'});
+    assert_styles(element, {color: 'red'});
 
     anim.player.startTime -= 0.5;
     assert_styles(element, {color: 'green'});


### PR DESCRIPTION
This change forces animation effects to apply themselves within the same script context that attached them to the document timeline.

Illustration:
// getComputedStyle(element).color === 'black';
element.animate([{color: 'green'}, {color: 'white'}], 1);
// getComputedStyle(element).color === 'green';

This simplifies some of the logic used when calling exitModifyCurrentAnimationState(). In almost all circumstances the player has undergone a tick before any animation state modification occurs.
