### PR TITLE
Reversed players are not finished when past their source duration

### DIFF
--- a/test/testcases.js
+++ b/test/testcases.js
@@ -68,6 +68,7 @@ var tests = [
   'test-pseudo-element-reference.html',
   'test-repeated-pause.html',
   'test-restart.html',
+  'test-reversed-player-active-phase.html',
   'test-rotation-not-reversed.html',
   'test-update-state.html',
   'unit-test-clone.html',

--- a/test/testcases/test-reversed-player-active-phase.html
+++ b/test/testcases/test-reversed-player-active-phase.html
@@ -1,0 +1,28 @@
+<style>
+#target {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background: black;
+}
+</style>
+<script src="../bootstrap.js"></script>
+<div id="target"></div>
+<script>
+timing_test(function() {
+    var player = target.animate([{left: '0px'}, {left: '100px'}], 2).player;
+
+    at(1, function() {
+        assert_styles(target, {left: '50px'});
+        player.currentTime = 3;
+        player.playbackRate = -1;
+        assert_styles(target, {left: '100px'});
+    }, 'Player reversing');
+
+    at(2, function() {}, 'Tick');
+
+    at(3, function() {
+        assert_styles(target, {left: '50px'});
+    }, 'Reversed player entering its active phase should take effect');
+});
+</script>

--- a/web-animations.js
+++ b/web-animations.js
@@ -387,6 +387,10 @@ Player.prototype = {
       this._registerOnTimeline();
     }
   },
+  _hasFutureAnimation: function() {
+    return this.source === null || this.playbackRate === 0 ||
+        this.source._hasFutureAnimation(this.playbackRate > 0);
+  },
   _isPastEndOfActiveInterval: function() {
     return this.source === null ||
         this.source._isPastEndOfActiveInterval();
@@ -767,6 +771,10 @@ TimedItem.prototype = {
     }
   },
   _getLeafItemsInEffectImpl: abstractMethod,
+  _hasFutureAnimation: function(timeDirectionForwards) {
+    return timeDirectionForwards ? this._inheritedTime < this.endTime :
+        this._inheritedTime > this.startTime;
+  },
   _isPastEndOfActiveInterval: function() {
     return this._inheritedTime >= this.endTime;
   },
@@ -5288,7 +5296,7 @@ var ticker = function(rafTime, isRepeat) {
   PLAYERS.forEach(function(player) {
     player._hasTicked = true;
     player._update();
-    finished = finished && player._isPastEndOfActiveInterval();
+    finished = finished && !player._hasFutureAnimation();
     if (!player._hasFutureEffect()) {
       finishedPlayers.push(player);
     }


### PR DESCRIPTION
Fix for bug #502.
Reversed players were being identified as finished when their current time was beyond their source content. This resulted in the next tick not being scheduled.
This change fixes this behaviour and takes the sign of the player's playback rate into account when determining whether it will enter its active phase in the future or not.
