### PR TITLE
Only show passing test results when --verbose is specified

### DIFF
--- a/tools/python/run-tests.py
+++ b/tools/python/run-tests.py
@@ -288,7 +288,6 @@ else:
 
 import subunit
 import testtools
-import unittest
 
 if args.list:
     data = file("test/testcases.js").read()
@@ -307,16 +306,17 @@ summary = testtools.StreamSummary()
 
 # Output information to stdout
 if not args.subunit:
+    # Output test failures
+    result_streams = [testtools.TextTestResult(sys.stdout)]
+    if args.verbose:
+        import unittest
+        # Output individual test progress
+        result_streams.insert(0,
+            unittest.TextTestResult(
+                unittest.runner._WritelnDecorator(sys.stdout), False, 2))
     # Human readable test output
     pertest = testtools.StreamToExtendedDecorator(
-        testtools.MultiTestResult(
-            # Individual test progress
-            unittest.TextTestResult(
-                unittest.runner._WritelnDecorator(sys.stdout), False, 2),
-            # End of run, summary of failures.
-            testtools.TextTestResult(sys.stdout),
-        )
-    )
+        testtools.MultiTestResult(*result_streams))
 else:
     from subunit.v2 import StreamResultToBytes
     pertest = StreamResultToBytes(sys.stdout)


### PR DESCRIPTION
The output of run-tests.sh is quite verbose spending one line for every test case that passes.
This change hides passing output unless --verbose is specified.

See Travis build log for this pull request for an example:
https://travis-ci.org/web-animations/web-animations-js/jobs/18785401
