### PR TITLE
Allow Android failures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
 # Disabled until travis-ci/travis-ci#1696 is fixed.
 #  fast_finish: true
   allow_failures:
+    # Disabled until Android build is fixed: https://github.com/web-animations/web-animations-js/issues/548
+    - env: BROWSER=Android-Chrome ARGS=''
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=INTERNETEXPLORER --remote-caps=version=10 --remote-caps=platform="Windows 8"'
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=SAFARI --remote-caps=version=6 --remote-caps=platform="OS X 10.8"'
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=IPHONE --remote-caps=version=6 --remote-caps=platform="OS X 10.8"'


### PR DESCRIPTION
Allow Android failures in Travis until #548 is fixed.
