### PR TITLE
Avoid capturing base values for empty compositable value stacks

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -4712,7 +4712,8 @@ CompositedPropertyMap.prototype = {
   },
   captureBaseValues: function() {
     for (var property in this.properties) {
-      if (this.stackDependsOnUnderlyingValue(this.properties[property])) {
+      var stack = this.properties[property];
+      if (stack.length > 0 && this.stackDependsOnUnderlyingValue(stack)) {
         var baseValue = fromCssValue(property, getValue(this.target, property));
         // TODO: Decide what to do with elements not in the DOM.
         ASSERT_ENABLED && assert(


### PR DESCRIPTION
Empty compositable value stacks do not require the underlying CSS value when they can just clear existing animation effects.
This is a modification of a change by timloh.
