### PR TITLE
Quiet test harness debug output for failing tests

### DIFF
--- a/tools/python/run-tests.py
+++ b/tools/python/run-tests.py
@@ -475,7 +475,7 @@ class ServerHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                     mime_type='text/plain; charset=UTF-8',
                     eof=True)
 
-            if 'debug' in data and overall_status > 0:
+            if args.verbose and 'debug' in data and overall_status > 0:
                 output.status(
                     test_id="%s:debug-log" % (test_id),
                     test_status='fail',


### PR DESCRIPTION
Only show test harness debug information for failing tests when --verbose is given to run-tests.sh.
