### PR TITLE
Avoid useless isDefinedAndNotNull() check in isEffectCallback() check

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -1078,9 +1078,7 @@ TimingEvent.prototype = Object.create(window.Event.prototype, {
 });
 
 var isEffectCallback = function(animationEffect) {
-  // TODO: How does WebIDL actually differentiate different callback interfaces?
-  return isDefinedAndNotNull(animationEffect) &&
-      typeof animationEffect === 'function';
+  return typeof animationEffect === 'function';
 };
 
 var interpretAnimationEffect = function(animationEffect) {


### PR DESCRIPTION
Removing this check results in an 8% performance improvement.
**Test:** test/perf/balls-replace-compositing.html
**Device:** Nexus 10
**Without patch:**

```
Average: 1.4581406928090335 FPS
Stddev: 0.024775606202678754 FPS
Min: 1.4187670245704818 FPS
Max: 1.5102616996442075 FPS
Median: 1.454523124706587 FPS
```

**With patch:**

```
Average: 1.5757391589373069 FPS
Stddev: 0.013885486397760056 FPS
Min: 1.5620597038094253 FPS
Max: 1.625558592747966 FPS
Median: 1.5697093291425672 FPS
```
