### PR TITLE
Check if Chrome debug log exists before copying

### DIFF
--- a/tools/python/run-tests.py
+++ b/tools/python/run-tests.py
@@ -748,8 +748,11 @@ except Exception, e:
 finally:
     output.stopTestRun()
 
-    if args.browser == "Chrome":
-        shutil.copy(os.path.join(user_data_dir, "chrome_debug.log"), ".")
+    # Chrome debug logging is currently broken in Canary:
+    # https://code.google.com/p/chromium/issues/detail?id=345582
+    # FIXME: Reenable this once the issue is fixed.
+    # if args.browser == "Chrome":
+    #     shutil.copy(os.path.join(user_data_dir, "chrome_debug.log"), ".")
 
 if summary.testsRun == 0:
     print

--- a/tools/python/run-tests.py
+++ b/tools/python/run-tests.py
@@ -748,11 +748,12 @@ except Exception, e:
 finally:
     output.stopTestRun()
 
-    # Chrome debug logging is currently broken in Canary:
-    # https://code.google.com/p/chromium/issues/detail?id=345582
-    # FIXME: Reenable this once the issue is fixed.
-    # if args.browser == "Chrome":
-    #     shutil.copy(os.path.join(user_data_dir, "chrome_debug.log"), ".")
+    if args.browser == "Chrome":
+        log_path = os.path.join(user_data_dir, "chrome_debug.log")
+        if os.path.exists(log_path):
+            shutil.copy(log_path, ".")
+        else:
+            print "Unable to find Chrome log file:", log_path
 
 if summary.testsRun == 0:
     print


### PR DESCRIPTION
#557

Chrome unstable channel debug logging is broken.
This patch makes run-tests.py more resilient to missing Chrome debug log files.
