### PR TITLE
Fix broken link to tooling strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,4 +226,4 @@ then the polyfill will provide a console warning in browsers where these feature
 ## Tools & testing
 
 For running tests or building minified files, consult the
-[tooling information](http://www.polymer-project.org/tooling-strategy.html).
+[tooling information](http://www.polymer-project.org/resources/tooling-strategy.html).


### PR DESCRIPTION
Should link to resources/tooling-strategy.html
