### PR TITLE
Added expected path test failures for Firefox 29

### DIFF
--- a/test/testcases/auto-test-path.html
+++ b/test/testcases/auto-test-path.html
@@ -106,7 +106,7 @@ var expected_failures = {
     message: "Doesn't quite follow path correctly."
   },
   '/#anim3 at t=5s/': {
-    firefox: ['28.0'],
+    firefox: ['28.0', '29.0'],
     message: "Doesn't quite follow path correctly."
   },
   '/#anim4 at t=(0|10)s/': {
@@ -114,7 +114,7 @@ var expected_failures = {
     message: "Doesn't quite follow path correctly."
   },
   '/#anim4 at t=(3|8|9)s/': {
-    firefox: ['28.0'],
+    firefox: ['28.0', '29.0'],
     message: "Doesn't quite follow path correctly."
   },
 
@@ -144,7 +144,7 @@ var expected_failures = {
 
   // Firefox & Android Chrome
   '/#anim2 at t=9s/' : {
-    firefox: ['28.0'],
+    firefox: ['28.0', '29.0'],
     android: true,
     message: "Firefox is non-visibly different and Android uses an integer SVG implementation."
   },


### PR DESCRIPTION
Firefox Aurora updated to version 29.0a2, some expected test failures need to be carried over from v28.
Matrices differ by less than 0.001, visually indistinguishable.
