### PR TITLE
Renames - AnimationGroup and AnimationSequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,20 +110,20 @@ feature.
 
 ### Sequencing and synchronizing animations
 
-Two different types of TimingGroups (`ParGroup` and `SeqGroup`) allow animations to be synchronized and sequenced.
+Two different types of TimingGroups (`AnimationGroup` and `AnimationSequence`) allow animations to be synchronized and sequenced.
 
 To play a list of animations in parallel:
 
-    var parGroup = new ParGroup([new Animation(...), new Animation(...)]);
+    var animationGroup = new AnimationGroup([new Animation(...), new Animation(...)]);
 
 To play a list in sequence:
 
-    var seqGroup = new SeqGroup([new Animation(...), new Animation(...)]);
+    var animationSequence = new AnimationSequence([new Animation(...), new Animation(...)]);
 
-Because `Animation`, `ParGroup`, `SeqGroup` are all TimedItems, groups can be nested:
+Because `Animation`, `AnimationGroup`, `AnimationSequence` are all TimedItems, groups can be nested:
 
-    var parGroup = new ParGroup([
-      new SeqGroup([
+    var animationGroup = new AnimationGroup([
+      new AnimationSequence([
         new Animation(...),
         new Animation(...),
       ]),
@@ -132,7 +132,7 @@ Because `Animation`, `ParGroup`, `SeqGroup` are all TimedItems, groups can be ne
 
 Groups also take an optional TimingDictionary parameter (see below), which among other things allows iteration and timing functions to apply at the group level:
 
-    var parGroup = new ParGroup([new Animation(...), new Animation(...)], {iterations: 4});
+    var animationGroup = new AnimationGroup([new Animation(...), new Animation(...)], {iterations: 4});
 
 ### Controlling the animation timing
 
@@ -160,8 +160,8 @@ backwards fills, and animation forwards fills. There are a few simple rules whic
 
 The following example illustrates these rules:
 
-    var parGroup = new ParGroup([
-      new SeqGroup([
+    var animationGroup = new AnimationGroup([
+      new AnimationSequence([
         new Animation(..., {duration: 3}),
         new Animation(..., {duration: 5, fill: 'both'})
       ], {duration: 6, delay: 3, fill: 'none'}),
@@ -170,14 +170,14 @@ The following example illustrates these rules:
 
 In this example:
 
-- The `SeqGroup` has an explicit `duration` of 6 seconds, and so the
+- The `AnimationSequence` has an explicit `duration` of 6 seconds, and so the
 second child animation will only play for the first 3 of its 5 second duration
-- The `ParGroup` has no explicit duration, and will be provided with a
+- The `AnimationGroup` has no explicit duration, and will be provided with a
 calculated duration of the max (`duration + delay`) of its children - in this case 9 seconds.
-- Although `fill: "both"` is specified for the second `Animation` within the `SeqGroup`, the `SeqGroup` itself has a `fill` of "none". Hence, as the animation ends right at the end of the `SeqGroup`, the animation will only fill backwards, and only up until the boundary of the `SeqGroup` (i.e. 3 seconds after the start of the `ParGroup`).
-- The `Animation` inside the `ParGroup` and the `ParGroup` are both `fill: "forward"`. Therefore the animation will fill forward in two places: 
-    - from 8 seconds after the `ParGroup` starts until the second iteration of the `ParGroup` starts (i.e. for 1 second)
-    - from 17 seconds after the `ParGroup` starts, extending forward indefinitely.
+- Although `fill: "both"` is specified for the second `Animation` within the `AnimationSequence`, the `AnimationSequence` itself has a `fill` of "none". Hence, as the animation ends right at the end of the `AnimationSequence`, the animation will only fill backwards, and only up until the boundary of the `AnimationSequence` (i.e. 3 seconds after the start of the `AnimationGroup`).
+- The `Animation` inside the `AnimationGroup` and the `AnimationGroup` are both `fill: "forward"`. Therefore the animation will fill forward in two places: 
+    - from 8 seconds after the `AnimationGroup` starts until the second iteration of the `AnimationGroup` starts (i.e. for 1 second)
+    - from 17 seconds after the `AnimationGroup` starts, extending forward indefinitely.
 
 ### Playing Animations
 

--- a/test/perf/balls-add-compositing.html
+++ b/test/perf/balls-add-compositing.html
@@ -132,13 +132,13 @@ window.addEventListener('load', function () {
   spacing.style.width = '600px';
   document.body.appendChild(spacing);
 
-  var parGroup = new ParGroup([], {iterations: Infinity, direction: 'alternate'});
+  var animationGroup = new AnimationGroup([], {iterations: Infinity, direction: 'alternate'});
   for (var i = 0; i < particleCount; i++) {
     var particle = new Particle();
-    parGroup.append(particle.generateAnimation(animationDuration));
+    animationGroup.append(particle.generateAnimation(animationDuration));
     particles.push(particle);
   }
-  player = document.timeline.play(parGroup);
+  player = document.timeline.play(animationGroup);
 
   Perf.oncomplete = cleanUp;
   Perf.start();

--- a/test/perf/balls-replace-compositing.html
+++ b/test/perf/balls-replace-compositing.html
@@ -129,13 +129,13 @@ window.addEventListener('load', function () {
   spacing.style.width = '600px';
   document.body.appendChild(spacing);
 
-  var parGroup = new ParGroup([], {iterations: Infinity, direction: 'alternate'});
+  var animationGroup = new AnimationGroup([], {iterations: Infinity, direction: 'alternate'});
   for (var i = 0; i < particleCount; i++) {
     var particle = new Particle();
-    parGroup.append(particle.generateAnimation(animationDuration));
+    animationGroup.append(particle.generateAnimation(animationDuration));
     particles.push(particle);
   }
-  player = document.timeline.play(parGroup);
+  player = document.timeline.play(animationGroup);
 
   Perf.oncomplete = cleanUp;
   Perf.start();

--- a/test/perf/updating-inline-style-during-animation.html
+++ b/test/perf/updating-inline-style-during-animation.html
@@ -148,13 +148,13 @@ window.addEventListener('load', function () {
   spacing.style.width = '600px';
   document.body.appendChild(spacing);
 
-  var parGroup = new ParGroup([], {iterations: Infinity, direction: 'alternate'});
+  var animationGroup = new AnimationGroup([], {iterations: Infinity, direction: 'alternate'});
   for (var i = 0; i < particleCount; i++) {
     var particle = new Particle();
-    parGroup.append(particle.generateAnimation(animationDuration));
+    animationGroup.append(particle.generateAnimation(animationDuration));
     particles.push(particle);
   }
-  player = document.timeline.play(parGroup);
+  player = document.timeline.play(animationGroup);
 
   raf(shakeParticles);
 

--- a/test/testcases/auto-test-delay.html
+++ b/test/testcases/auto-test-delay.html
@@ -32,7 +32,7 @@ limitations under the License.
 var anim = new Animation(a, [{ left: '100px'}, {left: '200px'}], 
   {delay: 0.2, duration: 0.3, endDelay: 0.4, iterations: 3, fill: 'both'});
 
-var par = new ParGroup([anim], {fill: 'none', iterations: 2})
+var par = new AnimationGroup([anim], {fill: 'none', iterations: 2})
 
 document.timeline.play(par);
 

--- a/test/testcases/auto-test-iteration-start.html
+++ b/test/testcases/auto-test-iteration-start.html
@@ -125,7 +125,7 @@ var effect100To180 = [{left: "100px"}, {left: "180px"}];
 for (var i = 0; i < directions.length; i++) {
   var dir = directions[i];
   groups.push(
-      new ParGroup([], {iterations: 2, direction: dir, duration: 4, fill: 'forwards'}));
+      new AnimationGroup([], {iterations: 2, direction: dir, duration: 4, fill: 'forwards'}));
 }
 
 for (var i = 0; i < containers.length; i++) {

--- a/test/testcases/auto-test-iterations-alternate-holes.html
+++ b/test/testcases/auto-test-iterations-alternate-holes.html
@@ -41,8 +41,8 @@ limitations under the License.
 var anim = new Animation(
     document.getElementById("a"), [{left: "100px"}, {left: "500px"}],
     {iterations: Infinity, duration: 1.0, fill: 'forwards'});
-var parGroup = new ParGroup([anim],
+var animationGroup = new AnimationGroup([anim],
     {direction: "alternate", duration: 1.0, iterations: 3.0, fill: 'forwards'});
 
-document.timeline.play(parGroup);
+document.timeline.play(animationGroup);
 </script>

--- a/test/testcases/auto-test-iterations-alternate.html
+++ b/test/testcases/auto-test-iterations-alternate.html
@@ -41,10 +41,10 @@ var anim1 = new Animation(
 var anim2 = new Animation(
     document.getElementById("b"), effect,
     {duration: 1.0, fill: 'forwards'});
-var parGroup = new ParGroup(
+var animationGroup = new AnimationGroup(
     [anim2],
     {duration: 1.0, iterations: 3.0, direction: "alternate", fill: 'forwards'});
 
 document.timeline.play(anim1);
-document.timeline.play(parGroup);
+document.timeline.play(animationGroup);
 </script>

--- a/test/testcases/auto-test-iterations-basic.html
+++ b/test/testcases/auto-test-iterations-basic.html
@@ -98,7 +98,7 @@ for (var i = 0; i < directions.length; i++) {
   var container = document.getElementById(containers[i]);
 
   document.timeline.play(
-      new ParGroup([
+      new AnimationGroup([
           // Test basic use.
           new Animation(container.getElementsByClassName("a")[0],
               [{left: "100px"}, {left: "300px"}],

--- a/test/testcases/auto-test-iterations-fill.html
+++ b/test/testcases/auto-test-iterations-fill.html
@@ -128,7 +128,7 @@ var groups = [];
 
 for (var i = 0; i < directions.length; i++) {
   var dir = directions[i];
-  groups.push(new ParGroup([], {
+  groups.push(new AnimationGroup([], {
     delay: 1,
     duration: 8,
     iterations: 3,

--- a/test/testcases/auto-test-parent.html
+++ b/test/testcases/auto-test-parent.html
@@ -45,7 +45,7 @@ document.timeline.play(new Animation(document.getElementById("a"),
     effect, timing));
 
 // Animation in group.
-document.timeline.play(new ParGroup([
+document.timeline.play(new AnimationGroup([
   new Animation(document.getElementById("c"), effect, timing)
 ], {iterations: 3}));
 

--- a/test/testcases/auto-test-pause.html
+++ b/test/testcases/auto-test-pause.html
@@ -69,10 +69,10 @@ var a1 = new Animation(document.querySelector("#a"), effect, {duration: 2.6, fil
 var a2 = new Animation(document.querySelector("#b"), effect, {duration: 2.5, fill: "forwards"});
 var a3 = new Animation(document.querySelector("#c"), effect, {duration: 2.5, fill: "forwards"});
 var a4 = new Animation(document.querySelector("#d"), effect, {duration: 2.3, fill: "forwards"});
-var pgroup1 = new ParGroup([a1, a2], {name: "p1", fill: "forwards"});
-var pgroup2 = new ParGroup([a3, a4], {name: "p2", fill: "forwards"});
+var pgroup1 = new AnimationGroup([a1, a2], {name: "p1", fill: "forwards"});
+var pgroup2 = new AnimationGroup([a3, a4], {name: "p2", fill: "forwards"});
 var player = document.timeline.play(
-    new SeqGroup([pgroup1, pgroup2], {name: "s", fill: "forwards"}));
+    new AnimationSequence([pgroup1, pgroup2], {name: "s", fill: "forwards"}));
 
 at(1.0, function() { player.pause(); });
 at(2.0, function() { player.play(); });

--- a/test/testcases/auto-test-playback-rate.html
+++ b/test/testcases/auto-test-playback-rate.html
@@ -101,7 +101,7 @@ var effect300To100 = [{left: "300px"}, {left: "100px"}];
 
 for (var i = 0; i < directions.length; i++) {
   var dir = directions[i];
-  groups.push(new ParGroup([], {direction: dir, duration: 3}));
+  groups.push(new AnimationGroup([], {direction: dir, duration: 3}));
 }
 
 for (var i = 0; i < containers.length; i++) {

--- a/test/testcases/auto-test-reparent.html
+++ b/test/testcases/auto-test-reparent.html
@@ -47,13 +47,13 @@ document.timeline.play(anim);
 
 // After 3.0s, move it to a parallel group and run that.
 testharness_timeline.schedule(function() {
-    document.timeline.play(new ParGroup([anim],
+    document.timeline.play(new AnimationGroup([anim],
         {duration: 1.0, iterations: 3.0}));
   }, 3000);
 
 // After 3.0s, move it to a parallel group and run that.
 testharness_timeline.schedule(function() {
-    document.timeline.play(new ParGroup([anim],
+    document.timeline.play(new AnimationGroup([anim],
         {duration: 1.5, iterations: 3.0}));
   }, 8000);
 

--- a/test/testcases/auto-test-seq-speed.html
+++ b/test/testcases/auto-test-seq-speed.html
@@ -78,9 +78,9 @@ var a3 = new Animation(
     document.querySelector("#c"), effect, {duration: 1.0, fill: "forwards"});
 var a4 = new Animation(
     document.querySelector("#d"), effect, {duration: 2.0, fill: "forwards"});
-var pgroup1 = new ParGroup([a1, a2], {name: "p1", fill: "forwards"});
-var pgroup2 = new ParGroup([a4, a3], {name: "p2", fill: "forwards"});
+var pgroup1 = new AnimationGroup([a1, a2], {name: "p1", fill: "forwards"});
+var pgroup2 = new AnimationGroup([a4, a3], {name: "p2", fill: "forwards"});
 document.timeline.play(
-    new SeqGroup([pgroup1, pgroup2], {name: "s", fill: "forwards"}));
+    new AnimationSequence([pgroup1, pgroup2], {name: "s", fill: "forwards"}));
 
 </script>

--- a/test/testcases/auto-test-start-time-iterations.html
+++ b/test/testcases/auto-test-start-time-iterations.html
@@ -90,9 +90,9 @@ for (var i = 0; i < directions.length; i++) {
   // addition, the child picks up a start time of zero. The parent then updates
   // its duration and its iteration time jumps, causing the child to start
   // playing part way through the animation.
-  var intrinsicGroup = new ParGroup([], {iterations: 2.0, direction: direction});
+  var intrinsicGroup = new AnimationGroup([], {iterations: 2.0, direction: direction});
   document.timeline.play(intrinsicGroup);
-  var fixedGroup = new ParGroup([], {iterations: 2.0, direction: direction, duration: 4.0});
+  var fixedGroup = new AnimationGroup([], {iterations: 2.0, direction: direction, duration: 4.0});
   document.timeline.play(fixedGroup);
 
   timing_test(function() {

--- a/test/testcases/auto-test-start-time.html
+++ b/test/testcases/auto-test-start-time.html
@@ -77,12 +77,12 @@ var animation = [{left: "100px"}, {left: "300px"}];
 for (var i = 0; i < directions.length; i++) {
   var container = document.getElementById(containers[i]);
   // Explicit parent duration.
-  document.timeline.play(new ParGroup(
+  document.timeline.play(new AnimationGroup(
       [new Animation(container.getElementsByClassName("a")[0], animation,
           {duration: 1.0, fill: 'forwards'})],
       {iterations: 2.0, direction: directions[i], duration: 1.0}));
   // Parent calculates intrinsic duration.
-  document.timeline.play(new ParGroup(
+  document.timeline.play(new AnimationGroup(
       [new Animation(container.getElementsByClassName("b")[0], animation,
           {duration: 1.0, fill: 'forwards'})],
       {iterations: 2.0, direction: directions[i]}));

--- a/test/testcases/auto-test-to-animation.html
+++ b/test/testcases/auto-test-to-animation.html
@@ -73,7 +73,7 @@ limitations under the License.
 
 var divs = document.querySelectorAll(".anim");
 
-var group = new ParGroup([], 2);
+var group = new AnimationGroup([], 2);
 
 for (var i = 0; i < divs.length; i++) {
   group.append(new Animation(divs[i], {left: (100 * (i+1)) + "px"}, {duration: 2, fill: 'forwards'}));

--- a/test/testcases/auto-test-wrapping-bug.html
+++ b/test/testcases/auto-test-wrapping-bug.html
@@ -34,23 +34,23 @@ limitations under the License.
 
 var effect = [{transform: "translate(-800px,0px)"}, {transform: "translate(0px,0px)"}];
 
-var group = new ParGroup();
-document.timeline.play(new ParGroup([
+var group = new AnimationGroup();
+document.timeline.play(new AnimationGroup([
     new Animation(overflow,
                   effect,
                   { duration: 0.3, delay: 0.25, fill: 'forwards' })]));
 
-document.timeline.play(new ParGroup([
+document.timeline.play(new AnimationGroup([
     new Animation(overflowControl,
                   effect,
                   { duration: 0.3, delay: 0.2, fill: 'forwards' })]));
 
-document.timeline.play(new ParGroup([
+document.timeline.play(new AnimationGroup([
     new Animation(underflow,
                   effect,
                   { duration: 0.3, delay: 0.20001, fill: 'none' })]));
 
-document.timeline.play(new ParGroup([
+document.timeline.play(new AnimationGroup([
     new Animation(underflowControl,
                   effect,
                   { duration: 0.3, delay: 0.2, fill: 'none' })]));

--- a/test/testcases/disabled-media.html
+++ b/test/testcases/disabled-media.html
@@ -327,7 +327,7 @@ timing_test(function() {
 timing_test(function() {
   var video = getNextVideo();
   at(0.0, function() {
-    dt.play(new ParGroup([createTestMediaReference(video, {playbackRate: 1.5})],
+    dt.play(new AnimationGroup([createTestMediaReference(video, {playbackRate: 1.5})],
         {playbackRate: 2.5}));
   });
   at(1.0, function() {
@@ -377,7 +377,7 @@ timing_test(function() {
 timing_test(function() {
   var video = getNextVideo();
   at(0.0, function() {
-    dt.play(new ParGroup(
+    dt.play(new AnimationGroup(
         [createTestMediaReference(video, {playbackRate: -0.5})],
         {playbackRate: 3.0, direction: "reverse"}));
   });

--- a/test/testcases/disabled-test-compositing-order.html
+++ b/test/testcases/disabled-test-compositing-order.html
@@ -44,11 +44,11 @@ var noop = {color: "red"};
 // because the second animation has a later start time, it should be composited
 // second, so the div should end up on the left.
 var target1 = document.getElementById("target1");
-var player = document.timeline.play(new ParGroup([
-  new ParGroup([
+var player = document.timeline.play(new AnimationGroup([
+  new AnimationGroup([
     new Animation(target1, leftToRight, 1.0),
   ]),
-  new SeqGroup([
+  new AnimationSequence([
     new Animation(target1, noop, 2.0),
     new Animation(target1, rightToLeft, 1.0),
   ]),
@@ -60,13 +60,13 @@ timing_test(function() {
 
 // Test that compositing order takes account of playback rate.
 //
-// The start time of the first animation is 0.0. The SeqGroup has a playback
+// The start time of the first animation is 0.0. The AnimationSequence has a playback
 // rate of 4.0, so the effective start time of its child animation is 2.0. So
 // the the div should end up on the left at time 3.0.
 var target2 = document.getElementById("target2");
-var player = document.timeline.play(new ParGroup([
+var player = document.timeline.play(new AnimationGroup([
   new Animation(target2, leftToRight, 1.0),
-  new SeqGroup([
+  new AnimationSequence([
     new Animation(target1, noop, 8.0),
     new Animation(target2, rightToLeft, 4.0),
   ], {playbackRate: 4.0}),
@@ -90,16 +90,16 @@ timing_test(function() {
 
 // Test compositing order follows tree order.
 var target4 = document.getElementById("target4");
-var player = document.timeline.play(new ParGroup([
+var player = document.timeline.play(new AnimationGroup([
   new Animation(target4, leftToRightLarge, 1.0),
-  new SeqGroup([
+  new AnimationSequence([
     new Animation(target4, leftToRightLarge, 1.0),
-    new ParGroup([
+    new AnimationGroup([
       new Animation(target4, leftToRightLarge, 1.0),
       new Animation(target4, leftToRightLarge, 1.0),
     ]),
   ]),
-  new ParGroup([
+  new AnimationGroup([
     new Animation(target4, leftToRightLarge, 1.0),
     new Animation(target4, leftToRight, 1.0),
   ]),

--- a/test/testcases/impl-test-player-sees-handlers.html
+++ b/test/testcases/impl-test-player-sees-handlers.html
@@ -58,8 +58,8 @@ test(function() {
 
 test(function() {
 
-  var aTree = new ParGroup([
-    new SeqGroup([
+  var aTree = new AnimationGroup([
+    new AnimationSequence([
       new Animation(body, {left: '100px'}, 1),
       new Animation(body, {left: '100px'}, 1)
     ]),
@@ -87,7 +87,7 @@ test(function() {
 test(function() {
   var anAnimation = new Animation(body, {left: '100px'}, 1);
   anAnimation.onstart = function() { };
-  var aGroup = new ParGroup([anAnimation]);
+  var aGroup = new AnimationGroup([anAnimation]);
   var player = document.timeline.play(aGroup);
   assert_true(player._needsHandlerPass);
 }, 'needsHandlerPass correctly passed from child to parent on construction');
@@ -95,7 +95,7 @@ test(function() {
 test(function() {
   var anAnimation = new Animation(body, {left: '100px'}, 1);
   anAnimation.onstart = function() { };
-  var aGroup = new ParGroup([]);
+  var aGroup = new AnimationGroup([]);
   aGroup.append(anAnimation);
   var player = document.timeline.play(aGroup);
   assert_true(player._needsHandlerPass);
@@ -104,7 +104,7 @@ test(function() {
 test(function() {
   var anAnimation = new Animation(body, {left: '100px'}, 1);
   anAnimation.onstart = function() { };
-  var aGroup = new ParGroup([]);
+  var aGroup = new AnimationGroup([]);
   var player = document.timeline.play(aGroup);
   aGroup.append(anAnimation);
   assert_true(player._needsHandlerPass);

--- a/test/testcases/manual-test-preset-timings.html
+++ b/test/testcases/manual-test-preset-timings.html
@@ -60,7 +60,7 @@ function testTiming(name) {
 // TODO: Making player global like this is is rather ugly. It would be nice if
 // the animation or player were passed to the custom animation effect's sample
 // function.
-var player = document.timeline.play(new ParGroup([
+var player = document.timeline.play(new AnimationGroup([
   testTiming('ease'),
   testTiming('linear'),
   testTiming('ease-in'),

--- a/test/testcases/manual-test-step.html
+++ b/test/testcases/manual-test-step.html
@@ -73,7 +73,7 @@ function testStep(numSteps, position) {
 // TODO: Making player global like this is is rather ugly. It would be nice if
 // the animation or player were passed to the custom animation effect's sample
 // function.
-var player = document.timeline.play(new ParGroup([
+var player = document.timeline.play(new AnimationGroup([
   testStep(1, 'start'),
   testStep(1, 'middle'),
   testStep(1, 'end'),

--- a/test/testcases/test-events.html
+++ b/test/testcases/test-events.html
@@ -137,23 +137,23 @@ testTiming(simple({duration: 5, delay: 5}),
   [event('start', 5, 5, 0), event('end', 10, 10, 0)],
   "delayed start");
 
-testTiming(new ParGroup([simple(10)]),
+testTiming(new AnimationGroup([simple(10)]),
   [event('start', 0, 0, 0), event('start', 0, 0, 0, child(0)),
    event('end', 10, 10, 0, child(0)), event('end', 10, 10, 0)],
    "simple par group");
 
-testTiming(new ParGroup([simple(10), simple(10)]),
+testTiming(new AnimationGroup([simple(10), simple(10)]),
   [event('start', 0, 0, 0), event('start', 0, 0, 0, child(0)),
    event('start', 0, 0, 0, child(1)), event('end', 10, 10, 0, child(0)),
    event('end', 10, 10, 0, child(1)), event('end', 10, 10, 0)],
    "par group with multiple children");
-testTiming(new SeqGroup([simple(5), simple(5)]),
+testTiming(new AnimationSequence([simple(5), simple(5)]),
   [event('start', 0, 0, 0), event('start', 0, 0, 0, child(0)),
    event('end', 5, 5, 0, child(0)), event('start', 0, 5, 0, child(1)),
    event('end', 5, 10, 0, child(1)), event('end', 10, 10, 0)],
    "seq group with multiple children");
 
-testTiming(new ParGroup([simple(5)], {duration: 5, 
+testTiming(new AnimationGroup([simple(5)], {duration: 5, 
                                        iterations: 2}),
   [event('start', 0, 0, 0), event('start', 0, 0, 0, child(0)),
    event('end', 5, 5, 0, child(0)), event('iteration', 5, 5, 1),
@@ -164,7 +164,7 @@ testTiming(new ParGroup([simple(5)], {duration: 5,
 // child at (0.5, 2.5, 4.5)
 // parent at ((-3), 2, 7)
 // result: child iterations at 1.5 | 2.5 4.5 6.5 | 7.5 9.5
-testTiming(new ParGroup([simple({duration: 2, iterationStart: 0.75,
+testTiming(new AnimationGroup([simple({duration: 2, iterationStart: 0.75,
                                  iterations: 2.5})],
                         {iterationStart: 0.6, iterations: 2}),
   [event('start', 0, 0, 0), event('iteration', 4.5, 1.5, 3, child(0)), 
@@ -181,13 +181,13 @@ testTiming(simple({duration: 10, playbackRate: 2}),
   [event('start', 0, 0, 0), event('end', 5, 5, 0)],
   "simple animation with non-unit playbackRate");
 
-testTiming(new ParGroup([simple({duration: 10, playbackRate: 4})], 
+testTiming(new AnimationGroup([simple({duration: 10, playbackRate: 4})], 
            {playbackRate: 0.5}),
   [event('start', 0, 0, 0), event('start', 0, 0, 0, child(0)),
    event('end', 2.5, 5, 0, child(0)), event('end', 5, 5, 0)],
    "nested non-unit playbackRates");
 
-testTiming(new ParGroup([simple({iterations: 2, duration: 2.5, 
+testTiming(new AnimationGroup([simple({iterations: 2, duration: 2.5, 
                                  playbackRate: 4})],
            {playbackRate: 0.5, iterations: 2}),
   [event('start', 0, 0, 0), event('start', 0, 0, 0, child(0)),

--- a/test/testcases/test-fill-auto.html
+++ b/test/testcases/test-fill-auto.html
@@ -32,7 +32,7 @@ function createAnim(element, fill) {
     });
 }
 function createGroup(element, fill) {
-  return new SeqGroup([
+  return new AnimationSequence([
       new Animation(element, effect, {
         duration: 0.1,
         fill: 'both'})

--- a/test/testcases/test-getcurrent.html
+++ b/test/testcases/test-getcurrent.html
@@ -57,7 +57,7 @@ at(2.0, function() {
   });
 var playerAB;
 at(3.0, function() {
-    playerAB = document.timeline.play(new ParGroup([animationAClone, animationBClone]));
+    playerAB = document.timeline.play(new AnimationGroup([animationAClone, animationBClone]));
   });
 
 // These test_at calls are not in a *-checks.js file so they

--- a/test/testcases/test-null-target.html
+++ b/test/testcases/test-null-target.html
@@ -44,7 +44,7 @@ var expected_failures = {
   var pause1 = new Animation(null, {left: "500px"}, timing);
   var pause2 = new Animation(null, null, timing);
   var down = new Animation(document.querySelector("#a"), {top: "450px"}, timing);
-  var combo = new SeqGroup([across, pause1, pause2, down]);
+  var combo = new AnimationSequence([across, pause1, pause2, down]);
   document.timeline.play(combo);
 
   timing_test(function() {

--- a/test/testcases/test-pause-for-testing.html
+++ b/test/testcases/test-pause-for-testing.html
@@ -30,9 +30,9 @@ limitations under the License.
 <script src='../bootstrap.js'></script>
 <script>
 'use strict';
-var downRed = new ParGroup(
+var downRed = new AnimationGroup(
     [new Animation(document.querySelector('#a'), {top: '600px'}, 4)]);
-var downBlue = new ParGroup(
+var downBlue = new AnimationGroup(
     [new Animation(document.querySelector('#b'), {top: '600px'}, 4)],
     {delay: 1});
 document.timeline.play(downRed);

--- a/test/testcases/test-player.html
+++ b/test/testcases/test-player.html
@@ -58,14 +58,14 @@ test(function() {assert_equals(animation.player,  player1)},
 // Test that TimedItem.player gives null on a detached tree.
 var animation2 =
     new Animation(document.getElementById("anim"), {left: "100px"});
-var parGroup = new ParGroup([animation2]);
-test(function() {assert_equals(parGroup.player,  null)},
+var animationGroup = new AnimationGroup([animation2]);
+test(function() {assert_equals(animationGroup.player,  null)},
      "TimedItem.player should be null for root");
 test(function() {assert_equals(animation2.player,  null)},
      "TimedItem.player should be null for leaf");
 
 // Test that TimedItem.player remotes to the root of the tree.
-var player3 = dt.play(parGroup);
+var player3 = dt.play(animationGroup);
 test(function() {assert_equals(animation2.player,  player3)},
      "TimedItem.player should remote");
 
@@ -74,25 +74,25 @@ test(function() {assert_equals(animation2.player,  player3)},
 var player4 = dt.play(animation2);
 test(function() {assert_equals(animation2.parent,  null)},
      "Animation should be reparented");
-test(function() {assert_equals(parGroup.children.length, 0)},
-     "Animation parent should be updated, leaving parGroup.children.length = 0");
+test(function() {assert_equals(animationGroup.children.length, 0)},
+     "Animation parent should be updated, leaving animationGroup.children.length = 0");
 test(function() {assert_equals(player4.source,  animation2)},
      "AnimationPlayer should use reparented animation");
 
 // Test that setting a parent on a TimedItem with an AnimationPlayer causes the
 // player to be disconnected.
-parGroup.append(animation2);
-test(function() {assert_equals(parGroup.player,  player3)},
+animationGroup.append(animation2);
+test(function() {assert_equals(animationGroup.player,  player3)},
      "TimedItem.player should be updated for root");
 test(function() {assert_equals(animation2.player,  player3)},
      "TimedItem.player should be updated for leaf");
 test(function() {assert_equals(player4.source,  null)},
      "AnimationPlayer.source should be updated");
-test(function() {assert_equals(animation2.parent,  parGroup)},
+test(function() {assert_equals(animation2.parent,  animationGroup)},
      "Animation.parent should be updated");
-test(function() {assert_equals(parGroup.children.length,  1)},
-      "Animation parent should be updated, leaving parGroup.children.length = 1");
-test(function() {assert_equals(parGroup.children[0],  animation2)},
+test(function() {assert_equals(animationGroup.children.length,  1)},
+      "Animation parent should be updated, leaving animationGroup.children.length = 1");
+test(function() {assert_equals(animationGroup.children[0],  animation2)},
      "Animation parent should be updated");
 
 // Test that currentTime is zero before timeline starts.

--- a/test/testcases/test-update-state.html
+++ b/test/testcases/test-update-state.html
@@ -66,7 +66,7 @@ timing_test(function() {
   });
 }, 'Updated style should be visible after change to specified timing');
 
-var group = new SeqGroup([
+var group = new AnimationSequence([
   new Animation(element, {}, 1),
   new Animation(element, [{right: '0px'}, {right: '1000px'}], 10),
 ]);
@@ -101,7 +101,7 @@ timing_test(function() {
     assert_styles(element, {bottom: '500px'});
 
     try {
-      var group = new ParGroup();
+      var group = new AnimationGroup();
       group.append(group);
     } catch (e) {
     }

--- a/test/testcases/unit-test-clone.html
+++ b/test/testcases/unit-test-clone.html
@@ -34,46 +34,46 @@ test(function() {assert_equals(clone.specified.duration, 1.0)},
 test(function() {assert_equals(clone.target, elem)},
      "Clone should take target");
 
-// ParGroup
-var parGroup = new ParGroup([anim, clone], 4.0);
-var parGroupClone = parGroup.clone();
-test(function() {assert_true(parGroupClone instanceof ParGroup, true)},
-     "ParGroup clone should be a ParGroup");
-test(function() {assert_equals(parGroupClone.specified.duration, 4.0)},
-     "ParGroup clone should take Timing.duration");
-test(function() {assert_equals(parGroupClone.children.length, 2)},
-     "ParGroup clone should clone children");
-test(function() {assert_not_equals(parGroupClone.children[0], anim)},
-     "ParGroup clone should clone first child");
-test(function() {assert_equals(parGroupClone.children[0].duration, 1.0)},
-     "ParGroup clone should clone first child's duration");
-test(function() {assert_not_equals(parGroupClone.children[1], clone)},
-     "ParGroup clone should clone second child");
-test(function() {assert_equals(parGroupClone.children[1].duration, 1.0)},
-     "ParGroup clone should clone second child's duration");
+// AnimationGroup
+var animationGroup = new AnimationGroup([anim, clone], 4.0);
+var animationGroupClone = animationGroup.clone();
+test(function() {assert_true(animationGroupClone instanceof AnimationGroup, true)},
+     "AnimationGroup clone should be a AnimationGroup");
+test(function() {assert_equals(animationGroupClone.specified.duration, 4.0)},
+     "AnimationGroup clone should take Timing.duration");
+test(function() {assert_equals(animationGroupClone.children.length, 2)},
+     "AnimationGroup clone should clone children");
+test(function() {assert_not_equals(animationGroupClone.children[0], anim)},
+     "AnimationGroup clone should clone first child");
+test(function() {assert_equals(animationGroupClone.children[0].duration, 1.0)},
+     "AnimationGroup clone should clone first child's duration");
+test(function() {assert_not_equals(animationGroupClone.children[1], clone)},
+     "AnimationGroup clone should clone second child");
+test(function() {assert_equals(animationGroupClone.children[1].duration, 1.0)},
+     "AnimationGroup clone should clone second child's duration");
 
-// SeqGroup
-var seqGroup = new SeqGroup([anim, clone], 6.0);
-var seqGroupClone = seqGroup.clone();
-test(function() {assert_true(seqGroupClone instanceof SeqGroup)},
-     "SeqGroup clone should be a SeqGroup");
-test(function() {assert_equals(seqGroupClone.specified.duration, 6.0)},
-     "SeqGroup clone should take Timing.duration");
-test(function() {assert_equals(seqGroupClone.children.length, 2)},
-     "SeqGroup clone should clone children");
-test(function() {assert_not_equals(seqGroupClone.children[0], anim)},
-     "SeqGroup clone should clone first child");
-test(function() {assert_equals(seqGroupClone.children[0].duration, 1.0)},
-     "SeqGroup clone should clone first child's duration");
-test(function() {assert_not_equals(seqGroupClone.children[1], clone)},
-     "SeqGroup clone should clone second child");
-test(function() {assert_equals(seqGroupClone.children[1].duration, 1.0)},
-     "SeqGroup clone should clone second child's duration");
+// AnimationSequence
+var animationSequence = new AnimationSequence([anim, clone], 6.0);
+var animationSequenceClone = animationSequence.clone();
+test(function() {assert_true(animationSequenceClone instanceof AnimationSequence)},
+     "AnimationSequence clone should be a AnimationSequence");
+test(function() {assert_equals(animationSequenceClone.specified.duration, 6.0)},
+     "AnimationSequence clone should take Timing.duration");
+test(function() {assert_equals(animationSequenceClone.children.length, 2)},
+     "AnimationSequence clone should clone children");
+test(function() {assert_not_equals(animationSequenceClone.children[0], anim)},
+     "AnimationSequence clone should clone first child");
+test(function() {assert_equals(animationSequenceClone.children[0].duration, 1.0)},
+     "AnimationSequence clone should clone first child's duration");
+test(function() {assert_not_equals(animationSequenceClone.children[1], clone)},
+     "AnimationSequence clone should clone second child");
+test(function() {assert_equals(animationSequenceClone.children[1].duration, 1.0)},
+     "AnimationSequence clone should clone second child's duration");
 
 // Child
 var childClone = anim.clone();
-test(function() {assert_equals(anim.parent, seqGroup)},
-     "Child clone should not equal seqGroup");
+test(function() {assert_equals(anim.parent, animationSequence)},
+     "Child clone should not equal animationSequence");
 test(function() {assert_equals(childClone.parent, null)},
      "Child clone should not take parent");
 

--- a/test/testcases/unit-test-delay.html
+++ b/test/testcases/unit-test-delay.html
@@ -25,7 +25,7 @@ var anim1 = new Animation(document.getElementById("anim"), {left: "100px"},
     {iterations: 3.0, duration: 1.0});
 var anim2 = new Animation(document.getElementById("anim"), {left: "100px"},
     {duration: 2.0});
-var parGroup = new ParGroup([anim1, anim2]);
+var animationGroup = new AnimationGroup([anim1, anim2]);
 
 function expectDuration(anim, duration, error) {
   test(function() {assert_equals(anim.activeDuration, duration)}, error);
@@ -37,22 +37,22 @@ function expectEndTime(anim, endTime, error) {
 
 expectDuration(anim1, 3.0, "Animation 1 duration should match specified value");
 expectDuration(anim2, 2.0, "Animation 2 duration should match specified value");
-expectDuration(parGroup, 3.0, 
-    "ParGroup duration should be max of childrens' end times");
+expectDuration(animationGroup, 3.0,
+    "AnimationGroup duration should be max of childrens' end times");
 anim1.specified.delay = 2.0;
 expectDuration(anim1, 3.0, "Animation 1 duration should not include delay");
 expectEndTime(anim1, 5.0, "Animation 1 end time should include delay");
-expectDuration(parGroup, 5.0, 
-    "ParGroup duration should still be max of childrens' end times");
+expectDuration(animationGroup, 5.0,
+    "AnimationGroup duration should still be max of childrens' end times");
 anim2.specified.endDelay = 4.0;
 expectDuration(anim2, 2.0, "Animation 2 duration should not include endDelay");
 expectEndTime(anim2, 6.0, "Animation 2 end time should include endDelay");
-expectDuration(parGroup, 6.0, 
-    "ParGroup duration should STILL be max of childrens' end times");
+expectDuration(animationGroup, 6.0,
+    "AnimationGroup duration should STILL be max of childrens' end times");
 
-var seqGroup = new SeqGroup([anim1, anim2]);
-expectDuration(seqGroup, 11.0, 
-    "SeqGroup duration should be sum of childrens' total durations");
+var animationSequence = new AnimationSequence([anim1, anim2]);
+expectDuration(animationSequence, 11.0,
+    "AnimationSequence duration should be sum of childrens' total durations");
 expectEndTime(anim2, 11.0, "Animation 2 end time should include Animation 1");
 anim1.specified.delay = 4.0;
 expectEndTime(anim2, 13.0,
@@ -61,6 +61,6 @@ anim1.specified.endDelay = 3.0;
 expectDuration(anim1, 3.0, "Animation 1 duration should not include endDelay");
 expectEndTime(anim1, 10.0, "Animation 1 end time should include endDelay");
 expectEndTime(anim2, 16.0, "Animation 2 end time should include Animation 1 endDelay");
-expectDuration(seqGroup, 16.0, 
-    "SeqGroup duration should still be sum of childrens' total durations");
+expectDuration(animationSequence, 16.0,
+    "AnimationSequence duration should still be sum of childrens' total durations");
 </script>

--- a/test/testcases/unit-test-dom-operations.html
+++ b/test/testcases/unit-test-dom-operations.html
@@ -25,7 +25,7 @@ var anims = [body, body, body, body, body, body, body, body, body, body].map(fun
 });
 
 function initGroup() {
- return new ParGroup(anims.slice(0, 5));
+ return new AnimationGroup(anims.slice(0, 5));
 }
 
 function toOrdering(list) {
@@ -37,7 +37,7 @@ function assert_child_order(group, list, message) {
 }
 
 test(function() {
-  var group = new ParGroup();
+  var group = new AnimationGroup();
   group.append(anims[5]);
   assert_child_order(group, [5],
     'append on empty group should work');
@@ -51,7 +51,7 @@ test(function() {
 }, 'append');
 
 test(function() {
-  var group = new ParGroup();
+  var group = new AnimationGroup();
   group.prepend(anims[5]);
   assert_child_order(group, [5],
     'prepend on empty group should work');
@@ -139,9 +139,9 @@ test(function() {
 
 test(function() {
   var group = initGroup();
-  var group2 = new ParGroup();
+  var group2 = new AnimationGroup();
   group2.append(group);
-  var group3 = new SeqGroup();
+  var group3 = new AnimationSequence();
   group3.append(group);
   assert_throws("HierarchyRequestError",
     function() {

--- a/test/testcases/unit-test-duration.html
+++ b/test/testcases/unit-test-duration.html
@@ -23,8 +23,8 @@ limitations under the License.
 
 var anim = new Animation(document.getElementById("anim"), {left: "100px"},
     {iterations: 3.0});
-var parGroup = new ParGroup();
-var seqGroup = new SeqGroup();
+var animationGroup = new AnimationGroup();
+var animationSequence = new AnimationSequence();
 
 // Should use intrinsic duration if Timing.duration is undefined.
 // Animation
@@ -33,24 +33,24 @@ test(function() {assert_equals(anim.duration,  0.0)},
 anim.specified.duration = 1.0;
 test(function() {assert_equals(anim.duration,  1.0)},
      "Animation duration should use specified value");
-// ParGroup
-test(function() {assert_equals(parGroup.duration,  0.0)},
-     "ParGroup duration should use intrinsic value");
-parGroup.append(anim);
-test(function() {assert_equals(parGroup.duration,  3.0)},
-     "ParGroup duration should be derived from child");
-parGroup.specified.duration = 2.0;
-test(function() {assert_equals(parGroup.duration,  2.0)},
-     "ParGroup duration should use specified value");
-// SeqGroup
-test(function() {assert_equals(seqGroup.duration,  0.0)},
-     "SeqGroup duration should use intrinsic value");
-seqGroup.append(anim);
-test(function() {assert_equals(seqGroup.duration,  3.0)},
-     "SeqGroup duration should be derived from child");
-seqGroup.specified.duration = 4.0;
-test(function() {assert_equals(seqGroup.duration,  4.0)},
-     "SeqGroup duration should use specified value");
+// AnimationGroup
+test(function() {assert_equals(animationGroup.duration,  0.0)},
+     "AnimationGroup duration should use intrinsic value");
+animationGroup.append(anim);
+test(function() {assert_equals(animationGroup.duration,  3.0)},
+     "AnimationGroup duration should be derived from child");
+animationGroup.specified.duration = 2.0;
+test(function() {assert_equals(animationGroup.duration,  2.0)},
+     "AnimationGroup duration should use specified value");
+// AnimationSequence
+test(function() {assert_equals(animationSequence.duration,  0.0)},
+     "AnimationSequence duration should use intrinsic value");
+animationSequence.append(anim);
+test(function() {assert_equals(animationSequence.duration,  3.0)},
+     "AnimationSequence duration should be derived from child");
+animationSequence.specified.duration = 4.0;
+test(function() {assert_equals(animationSequence.duration,  4.0)},
+     "AnimationSequence duration should use specified value");
 
 test(function() {
   assert_throws(new TypeError(), function() {

--- a/test/testcases/unit-test-get-siblings.html
+++ b/test/testcases/unit-test-get-siblings.html
@@ -21,7 +21,7 @@ limitations under the License.
 <script>
 "use strict";
 
-var parGroup = new ParGroup();
+var animationGroup = new AnimationGroup();
 var anim = new Animation(document.getElementById("anim"), {left: "100px"},
     {iterations: 3.0});
 var anim1 = new Animation(document.getElementById("anim"), {top: "100px"},
@@ -37,15 +37,15 @@ test(function() {assert_equals(anim.previousSibling, null)},
 test(function() {assert_equals(anim.nextSibling, null)},
      "Single animation should have no next sibling");
 
-parGroup.append(anim);
+animationGroup.append(anim);
 
 test(function() {assert_equals(anim.previousSibling, null)},
-     "Single animation in a parGroup should have no previous sibling");
+     "Single animation in a animationGroup should have no previous sibling");
 
 test(function() {assert_equals(anim.nextSibling, null)},
-     "Single animation in a parGroup should have no next sibling");
+     "Single animation in a animationGroup should have no next sibling");
 
-parGroup.prepend(anim1);
+animationGroup.prepend(anim1);
 
 test(function() {assert_equals(anim.previousSibling, anim1)},
      "Animation should have a previous sibling when there is one");
@@ -53,7 +53,7 @@ test(function() {assert_equals(anim.previousSibling, anim1)},
 test(function() {assert_equals(anim.nextSibling, null)},
      "Animation should have no next sibling when there is none");
 
-parGroup.append(anim2);
+animationGroup.append(anim2);
 
 test(function() {assert_equals(anim.previousSibling, anim1)},
      "Animation should have a previous sibling when there is one");
@@ -61,7 +61,7 @@ test(function() {assert_equals(anim.previousSibling, anim1)},
 test(function() {assert_equals(anim.nextSibling, anim2)},
      "Animation should have a next sibling when there is one");
 
-parGroup.prepend(anim3);
+animationGroup.prepend(anim3);
 
 test(function() {assert_equals(anim.previousSibling, anim1)},
      "Animation should have the correct previous sibling when there is more than one");
@@ -77,7 +77,7 @@ test(function() {assert_equals(anim.nextSibling, anim2)},
      "Animation should have a next sibling when there is one");
 
 anim3.remove();
-parGroup.append(anim3);
+animationGroup.append(anim3);
 
 test(function() {assert_equals(anim.previousSibling, null)},
      "Animation should have the no previous sibling when there is none");

--- a/test/testcases/unit-test-modify-timing-params.html
+++ b/test/testcases/unit-test-modify-timing-params.html
@@ -51,22 +51,22 @@ test(function() {
 // Test that updates to a TimedItem's endTime cause re-layout of a parent
 // parallel group.
 anim.specified.duration = 3;
-var parGroup = new ParGroup([anim]);
-test(function() {assert_equals(parGroup.duration,  3.0)},
+var animationGroup = new AnimationGroup([anim]);
+test(function() {assert_equals(animationGroup.duration,  3.0)},
      "Parallel group duration should reflect child endTime");
-test(function() {assert_equals(parGroup.endTime,  3.0)},
+test(function() {assert_equals(animationGroup.endTime,  3.0)},
      "Parallel group end time should reflect child endTime");
 // Update via Timing.duration
 anim.specified.duration = 8.0;
-test(function() {assert_equals(parGroup.duration,  8.0)},
+test(function() {assert_equals(animationGroup.duration,  8.0)},
      "Parallel group duration should reflect updated child Timing.duration");
-test(function() {assert_equals(parGroup.endTime,  8.0)},
+test(function() {assert_equals(animationGroup.endTime,  8.0)},
      "Parallel group end time should reflect updated child Timing.duration");
 // Update via duration
 anim.specified.duration = 9.0;
-test(function() {assert_equals(parGroup.duration,  9.0)},
+test(function() {assert_equals(animationGroup.duration,  9.0)},
      "Parallel group duration should reflect updated child duration");
-test(function() {assert_equals(parGroup.endTime,  9.0)},
+test(function() {assert_equals(animationGroup.endTime,  9.0)},
      "Parallel group end time should reflect updated child duration");
 
 // Test that updates to a TimedItem's delay and duration cause
@@ -74,32 +74,32 @@ test(function() {assert_equals(parGroup.endTime,  9.0)},
 anim.specified.duration = "auto";
 var siblingAnim = new Animation(document.getElementById("anim"), {top: "100px"},
     1.0);
-var seqGroup = new SeqGroup([anim, siblingAnim]);
+var animationSequence = new AnimationSequence([anim, siblingAnim]);
 test(function() {assert_equals(anim.startTime,  0.0)},
      "Sequence group should reset child startTime");
 test(function() {assert_equals(siblingAnim.startTime,  0.0)},
      "Sequence group should set child startTime");
 test(function() {assert_equals(siblingAnim.endTime,  1.0)},
      "Sequence group should set child endTime");
-test(function() {assert_equals(seqGroup.duration,  1.0)},
+test(function() {assert_equals(animationSequence.duration,  1.0)},
      "Sequence group duration should reflect child durations");
-test(function() {assert_equals(seqGroup.endTime,  1.0)},
+test(function() {assert_equals(animationSequence.endTime,  1.0)},
      "Sequence group end time should reflect child durations");
 // delay
 anim.specified.delay = 11.0;
 test(function() {assert_equals(siblingAnim.startTime,  11.0)},
      "Sequence group should update sibling after updated child delay");
-test(function() {assert_equals(seqGroup.duration,  12.0)},
+test(function() {assert_equals(animationSequence.duration,  12.0)},
      "Sequence group duration should reflect updated child delay");
-test(function() {assert_equals(seqGroup.endTime,  12.0)},
+test(function() {assert_equals(animationSequence.endTime,  12.0)},
      "Sequence group end time should reflect updated child delay");
 // duration
 anim.specified.duration = 12.0;
 test(function() {assert_equals(siblingAnim.startTime,  23.0)},
      "Sequence group should update sibling after updated child Timing.duration");
-test(function() {assert_equals(seqGroup.duration,  24.0)},
+test(function() {assert_equals(animationSequence.duration,  24.0)},
      "Sequence group duration should reflect updated child Timing.duration");
-test(function() {assert_equals(seqGroup.endTime,  24.0)},
+test(function() {assert_equals(animationSequence.endTime,  24.0)},
      "Sequence group end time should reflect updated child Timing.duration");
 
 </script>

--- a/test/testcases/unit-test-set-parent.html
+++ b/test/testcases/unit-test-set-parent.html
@@ -30,12 +30,12 @@ test(function() {assert_equals(child.parent, null)},
     "Child should have no parent");
 
 // Test that group is constructed with zero children.
-var parent = new ParGroup();
+var parent = new AnimationGroup();
 test(function() {assert_equals(parent.children.length, 0)},
     "Parent should have zero children");
 
 // Test that updates are made to child when constructing parent.
-var parent = new ParGroup([child]);
+var parent = new AnimationGroup([child]);
 test(function() {assert_equals(child.parent, parent)},
     "Parent's constructor, Child's parent should be set to parent");
 test(function() {assert_equals(parent.children.length, 1)},
@@ -44,7 +44,7 @@ test(function() {assert_equals(parent.children[0], child)},
     "Parent's constructor, Parent should have correct child");
 
 // Test that updates are made to previous and new parent when using append().
-var newParent = new ParGroup();
+var newParent = new AnimationGroup();
 newParent.append(child);
 test(function() {assert_equals(child.parent, newParent)},
     "With .append, child's parent should be updated to new parent");
@@ -58,23 +58,23 @@ test(function() {assert_equals(newParent.children[0], child)},
 // Test that calling append() with an existing child causes that child to be moved
 // to the end of the list of children.
 var sibling = new Animation(elem, animFunc, 1.0);
-var seqGroup = new SeqGroup([child, sibling]);
-test(function() {assert_equals(seqGroup.children.length, 2)},
-    "Moved child, new seqGroup.children.length");
-test(function() {assert_equals(seqGroup.children[0], child)},
-    "Moved child, new seqGroup's first child should be 'child'");
-test(function() {assert_equals(seqGroup.children[1], sibling)},
+var animationSequence = new AnimationSequence([child, sibling]);
+test(function() {assert_equals(animationSequence.children.length, 2)},
+    "Moved child, new animationSequence.children.length");
+test(function() {assert_equals(animationSequence.children[0], child)},
+    "Moved child, new animationSequence's first child should be 'child'");
+test(function() {assert_equals(animationSequence.children[1], sibling)},
     "Moved child, Second child should be 'sibling'");
 test(function() {assert_equals(child.startTime, 0.0)},
     "Moved child, start time of 'child' == 0.0");
 test(function() {assert_equals(sibling.startTime, 1.0)},
     "Moved child, start time of 'sibling' == 1.0");
-seqGroup.append(seqGroup.children[0]);
-test(function() {assert_equals(seqGroup.children.length, 2)},
-     "After .append, seqGroup.children.length");
-test(function() {assert_equals(seqGroup.children[0], sibling)},
+animationSequence.append(animationSequence.children[0]);
+test(function() {assert_equals(animationSequence.children.length, 2)},
+     "After .append, animationSequence.children.length");
+test(function() {assert_equals(animationSequence.children[0], sibling)},
      "After .append, First child should be 'sibling'");
-test(function() {assert_equals(seqGroup.children[1], child)},
+test(function() {assert_equals(animationSequence.children[1], child)},
      "After .append, Second child should be 'child'");
 test(function() {assert_equals(sibling.startTime, 0.0)},
      "After .append, Start time of 'sibling'");
@@ -86,13 +86,13 @@ test(function() {
   assert_throws(new TypeError(), function() {
     child.parent = null;
   });
-  assert_equals(child.parent, seqGroup);
+  assert_equals(child.parent, animationSequence);
 }, "TimedItem.parent should be read-only");
-test(function() {assert_equals(seqGroup.children.length, 2)},
-     "seqGroup.children.length");
-test(function() {assert_equals(seqGroup.children[0], sibling)},
+test(function() {assert_equals(animationSequence.children.length, 2)},
+     "animationSequence.children.length");
+test(function() {assert_equals(animationSequence.children[0], sibling)},
      "First child should be 'sibling'");
-test(function() {assert_equals(seqGroup.children[1], child)},
+test(function() {assert_equals(animationSequence.children[1], child)},
      "Second child should be 'child'");
 test(function() {assert_equals(sibling.startTime, 0.0)},
      "Start time of 'sibling'");
@@ -100,8 +100,8 @@ test(function() {assert_equals(child.startTime, 1.0)},
      "Start time of 'child'");
 
 // Test that TimedItem.clear() updates both parent and children.
-seqGroup.clear();
-test(function() {assert_equals(seqGroup.children.length, 0)},
+animationSequence.clear();
+test(function() {assert_equals(animationSequence.children.length, 0)},
      "Parent's children should be cleared");
 test(function() {assert_equals(child.parent, null)},
      "Child's parent should be cleared");

--- a/tutorial/parallel/parallel-exercise-1.html
+++ b/tutorial/parallel/parallel-exercise-1.html
@@ -47,7 +47,7 @@ limitations under the License.
         {top: "500px"}, 5); <br />
         var C = new Animation(document.querySelector("#c"), 
         {top: "700px"}, 5); <br />
-        new ParGroup([A, B, C]);
+        new AnimationGroup([A, B, C]);
     </code>
   </div>
 

--- a/tutorial/parallel/parallel.html
+++ b/tutorial/parallel/parallel.html
@@ -75,7 +75,7 @@ limitations under the License.
     <p class="description">The following is the interface for creating 
     a parallel animation group.</p>
 
-    <code class="codeSamples">new ParGroup([children], 
+    <code class="codeSamples">new AnimationGroup([children], 
     {timing/timing dictionary});</code>
 
     <p class="description note">Note that both children and timing are 

--- a/web-animations.js
+++ b/web-animations.js
@@ -644,8 +644,8 @@ TimedItem.prototype = {
         this.remove();
       }
       this._parent = parent;
-      // In the case of a SeqGroup parent, _startTime will be updated by
-      // TimingGroup.splice().
+      // In the case of a AnimationSequence parent, _startTime will be updated
+      // by TimingGroup.splice().
       if (this.parent === null || this.parent.type !== 'seq') {
         this._startTime =
             this._stashedStartTime === undefined ? 0.0 : this._stashedStartTime;
@@ -1448,8 +1448,8 @@ TimingGroup.prototype = createObject(TimedItem.prototype, {
       children.push(child.clone());
     });
     return this.type === 'par' ?
-        new ParGroup(children, this.specified._dict) :
-        new SeqGroup(children, this.specified._dict);
+        new AnimationGroup(children, this.specified._dict) :
+        new AnimationSequence(children, this.specified._dict);
   },
   clear: function() {
     this._splice(0, this._children.length);
@@ -1563,20 +1563,20 @@ TimingGroup.prototype = createObject(TimedItem.prototype, {
 
 
 /** @constructor */
-var ParGroup = function(children, timing, parent) {
+var AnimationGroup = function(children, timing, parent) {
   TimingGroup.call(this, constructorToken, 'par', children, timing, parent);
 };
 
-ParGroup.prototype = Object.create(TimingGroup.prototype);
+AnimationGroup.prototype = Object.create(TimingGroup.prototype);
 
 
 
 /** @constructor */
-var SeqGroup = function(children, timing, parent) {
+var AnimationSequence = function(children, timing, parent) {
   TimingGroup.call(this, constructorToken, 'seq', children, timing, parent);
 };
 
-SeqGroup.prototype = Object.create(TimingGroup.prototype);
+AnimationSequence.prototype = Object.create(TimingGroup.prototype);
 
 
 
@@ -5317,13 +5317,13 @@ window.Element.prototype.getCurrentAnimations = function() {
 
 window.Animation = Animation;
 window.AnimationEffect = AnimationEffect;
+window.AnimationGroup = AnimationGroup;
 window.AnimationPlayer = AnimationPlayer;
+window.AnimationSequence = AnimationSequence;
 window.KeyframeEffect = KeyframeEffect;
 window.MediaReference = MediaReference;
-window.ParGroup = ParGroup;
 window.MotionPathEffect = MotionPathEffect;
 window.PseudoElementReference = PseudoElementReference;
-window.SeqGroup = SeqGroup;
 window.TimedItem = TimedItem;
 window.TimedItemList = TimedItemList;
 window.Timing = Timing;


### PR DESCRIPTION
Rename ParGroup to AnimationGroup
Rename SeqGroup to AnimationSequence

From Web Animations minutes, 27 Feb 2014
https://etherpad.mozilla.org/ep/pad/view/ro.WCBLOuse6D5/latest
