### PR TITLE
Rename Timeline to AnimationTimeline

### DIFF
--- a/test/testcases.js
+++ b/test/testcases.js
@@ -46,6 +46,7 @@ var tests = [
   'auto-test-transform-units.html',
   'auto-test-visibility.html',
   'auto-test-wrapping-bug.html',
+  'impl-test-deprecation.html',
   'impl-test-from-css-value.html',
   'impl-test-paced-timing-function.html',
   'impl-test-player-sees-handlers.html',

--- a/test/testcases/impl-test-deprecation.html
+++ b/test/testcases/impl-test-deprecation.html
@@ -1,0 +1,85 @@
+<!--
+Copyright 2014 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html><meta charset="UTF-8">
+<script src="../bootstrap.js"></script>
+<script>
+"use strict";
+
+var useAncient = function(deprecationDate) {
+  _WebAnimationsTestingUtilities._deprecated('Ancient', deprecationDate,
+      'Please use Modern instead.');
+};
+
+var useOld = function(deprecationDate) {
+  _WebAnimationsTestingUtilities._deprecated('Old', deprecationDate,
+      'Please use New instead.');
+};
+
+var useSuperseded = function(deprecationDate) {
+  _WebAnimationsTestingUtilities._deprecated('Superseded', deprecationDate,
+      'See Replacement.');
+};
+
+test(function() {
+  var deprecationDate = new Date();
+  deprecationDate.setDate(deprecationDate.getDate() - 85);
+  var cutoffDate = new Date(deprecationDate);
+  cutoffDate.setMonth(cutoffDate.getMonth() + 3); // 3 months grace period
+
+  var warnings = [];
+  var savedConsoleWarn = console.warn;
+  try {
+    console.warn = function(message) {
+      warnings.push(message);
+    };
+
+    var firstExpectedWarning = 'Web Animations: Old is deprecated and will stop working on ' + cutoffDate.toDateString() + '. Please use New instead.';
+    var secondExpectedWarning = 'Web Animations: Superseded is deprecated and will stop working on ' + cutoffDate.toDateString() + '. See Replacement.';
+
+    useOld(deprecationDate);
+    assert_equals(warnings.length, 1);
+    assert_equals(warnings[0], firstExpectedWarning);
+
+    useOld(deprecationDate);
+    assert_equals(warnings.length, 1);
+
+    useSuperseded(deprecationDate);
+    assert_equals(warnings.length, 2);
+    assert_equals(warnings[1], secondExpectedWarning);
+
+    useSuperseded(deprecationDate);
+    assert_equals(warnings.length, 2);
+  } finally {
+    console.warn = savedConsoleWarn;
+  }
+}, 'Warn the first time each recently deprecated feature is used');
+
+test(function() {
+  var deprecationDate = new Date(new Date());
+  deprecationDate.setDate(deprecationDate.getDate() - 95);
+
+  for (var i = 0; i < 2; ++i) {
+    try {
+      useAncient();
+      assert_true(false);
+    } catch (e) {
+      assert_equals(e.message, 'Ancient is no longer supported. Please use Modern instead.');
+    }
+  }
+}, 'Throw each time an anciently deprecated feature is used');
+
+</script>

--- a/test/testcases/impl-test-totimelinetime.html
+++ b/test/testcases/impl-test-totimelinetime.html
@@ -18,9 +18,9 @@ limitations under the License.
 <script>
 "use strict";
 
-var timelineOne = new Timeline(_WebAnimationsTestingUtilities._constructorToken);
+var timelineOne = new AnimationTimeline(_WebAnimationsTestingUtilities._constructorToken);
 timelineOne._startTime = 3;
-var timelineTwo = new Timeline(_WebAnimationsTestingUtilities._constructorToken);
+var timelineTwo = new AnimationTimeline(_WebAnimationsTestingUtilities._constructorToken);
 timelineTwo._startTime = 42;
 
 test(function() {


### PR DESCRIPTION
Rename Timeline to AnimationTimeline
(From Web Animations minutes 27 Feb 2014
https://etherpad.mozilla.org/ep/pad/view/ro.WCBLOuse6D5/latest )

Introduce deprecation reporting, where a deprecated feature continues to
work for three months after deprecation, but a warning is logged to the
console when the feature is first used.

Illustrate how the deprecation reporting system is used, using the
obsolete Timeline constructor.
