### PR TITLE
Update Chrome Android APK name

### DIFF
--- a/run-tests-android.sh
+++ b/run-tests-android.sh
@@ -7,13 +7,19 @@ git submodule update
 # Set up the android environment
 source tools/android/setup.sh
 
-cat > load-list.txt <<EOF
-^[a].*
-EOF
-./run-tests.sh -b Remote --remote-executor http://localhost:9515 --remote-caps="chromeOptions=androidPackage=$CHROME_APP" --load-list load-list.txt --verbose || exit 1
-cat > load-list.txt <<EOF
-^[^a].*
-EOF
-./run-tests.sh -b Remote --remote-executor http://localhost:9515 --remote-caps="chromeOptions=androidPackage=$CHROME_APP" --load-list load-list.txt --verbose || exit 1
+function run_tests() {
+  ./run-tests.sh \
+    -b Remote \
+    --remote-executor http://localhost:9515 \
+    --remote-caps="chromeOptions=androidPackage=$CHROME_APP" \
+    --load-list load-list.txt \
+    --verbose || exit 1
+}
+
+# We split the test runs into two groups to avoid running out of memory in Travis.
+echo "^[a].*" > load-list.txt
+run_tests
+echo "^[^a].*" > load-list.txt
+run_tests
 
 echo "Run $ANDROID_DIR/stop.sh if finished."

--- a/test/testcases/auto-test-path.html
+++ b/test/testcases/auto-test-path.html
@@ -97,6 +97,10 @@ var expected_failures = {
     firefox: ['26.0', '27.0'],
     message: "Doesn't quite follow path correctly."
   },
+  '/#anim2 at t=9s/' : {
+    firefox: ['28.0', '29.0', '30.0'],
+    message: "Doesn't quite follow path correctly."
+  },
   '/#anim3 at t=(0|7|8|10)s/': {
     firefox: true,
     message: "Doesn't quite follow path correctly."
@@ -130,23 +134,6 @@ var expected_failures = {
   '/#anim4 at t=(0|1|3|9|10|11)s/': {
     msie: true,
     message: "Doesn't quite follow path correctly."
-  },
-
-  // Android Chrome
-  '/#anim3 at t=(7|8)s/' : {
-    android: true,
-    message: "Android uses integer SVG implementation."
-  },
-  '/#anim4 at t=8s/' : {
-    android: true,
-    message: "Android uses integer SVG implementation."
-  },
-
-  // Firefox & Android Chrome
-  '/#anim2 at t=9s/' : {
-    firefox: ['28.0', '29.0', '30.0'],
-    android: true,
-    message: "Firefox is non-visibly different and Android uses an integer SVG implementation."
   },
 };
 </script>

--- a/tools/android/setup.sh
+++ b/tools/android/setup.sh
@@ -90,15 +90,15 @@ if [ -e Chrome.apk ]; then
   CHROME_APP=com.google.android.apps.chrome
   CHROME_ACT=.Main
 else
-  if [ ! -e chrome-android/apks/ChromiumTestShell.apk ]; then
+  if [ ! -e chrome-android/apks/ChromeShell.apk ]; then
     LATEST=`curl -s http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/LAST_CHANGE`
     REMOTE_APK=http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/$LATEST/chrome-android.zip
     wget -c $REMOTE_APK
     unzip chrome-android.zip
   fi
-  CHROME_APK=$ANDROID_DIR/chrome-android/apks/ChromiumTestShell.apk
-  CHROME_APP=org.chromium.chrome.testshell
-  CHROME_ACT=.ChromiumTestShellActivity
+  CHROME_APK=$ANDROID_DIR/chrome-android/apks/ChromeShell.apk
+  CHROME_APP=org.chromium.chrome.shell
+  CHROME_ACT=.ChromeShellActivity
 fi
 
 function start_chrome () {

--- a/tools/android/setup.sh
+++ b/tools/android/setup.sh
@@ -91,8 +91,8 @@ if [ -e Chrome.apk ]; then
   CHROME_ACT=.Main
 else
   if [ ! -e chrome-android/apks/ChromeShell.apk ]; then
-    LATEST=`curl -s http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/LAST_CHANGE`
-    REMOTE_APK=http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/$LATEST/chrome-android.zip
+    LATEST_APK=`curl -s http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/LAST_CHANGE`
+    REMOTE_APK=http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/$LATEST_APK/chrome-android.zip
     wget -c $REMOTE_APK
     unzip chrome-android.zip
   fi
@@ -123,8 +123,14 @@ fi
 
 # Download and start the chromedriver binary
 if [ ! -e chromedriver ]; then
-  wget -c http://chromedriver.storage.googleapis.com/2.6/chromedriver_linux64.zip -O chromedriver.zip
-  unzip chromedriver.zip
+  # TODO: Use the latest release of chromedriver instead of this custom build once version 3.0 comes out.
+  # LATEST_CHROMEDRIVER=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+  # wget -c http://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER/chromedriver_linux64.zip -O chromedriver.zip
+  # unzip chromedriver.zip
+
+  # This version of chromedriver was build from the Chromium repository at r262639 on 2014-04-09.
+  wget https://googledrive.com/host/0B6C-LL9qmW-IYVFrdURCMHZlM1U -O chromedriver
+  chmod 0755 chromedriver
 fi
 
 CHROMEDRIVER_NOTRUNNING=true


### PR DESCRIPTION
The continuous Chrome Android test shell changed names not long ago, this changes our infrastructure to use the updated name.
This also updates the test scripts to use a tip-of-tree build of ChromeDriver that works with the latest Android test shell naming.
