### PR TITLE
Silence Android failures while Android testing infrastructure is broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
 # Disabled until travis-ci/travis-ci#1696 is fixed.
 #  fast_finish: true
   allow_failures:
+    - env: BROWSER=Android-Chrome ARGS=''
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=INTERNETEXPLORER --remote-caps=version=10 --remote-caps=platform="Windows 8"'
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=SAFARI --remote-caps=version=6 --remote-caps=platform="OS X 10.8"'
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=IPHONE --remote-caps=version=6 --remote-caps=platform="OS X 10.8"'


### PR DESCRIPTION
Currently Android failures are not useful to pull requests because of the broken state of the Android Chromium test shell integration. This change silences the failure in pull request Travis states for the short term.
