### PR TITLE
Rename TimedItem.specified to TimedItem.timing

### DIFF
--- a/test/testcases/disabled-auto-test-change-playback-rate.html
+++ b/test/testcases/disabled-auto-test-change-playback-rate.html
@@ -59,7 +59,7 @@ var a2 = new Animation(undefined,
       player2.playbackRate = playbackRate;
       document.querySelector("#a").textContent = playbackRate;
     },
-    a1.specified.clone());
+    a1.timing.clone());
 var player2 = document.timeline.play(a2);
 
 </script>

--- a/test/testcases/test-fill-auto.html
+++ b/test/testcases/test-fill-auto.html
@@ -69,8 +69,8 @@ timing_test(function() {
     assert_false(inEffect(animElement), 'Animations should not be in effect by default after they end.');
     assert_true(inEffect(groupElement), 'Timing Groups should be in effect by default before after they end.');
 
-    changingAnim.specified.fill = 'auto';
-    changingGroup.specified.fill = 'auto';
+    changingAnim.timing.fill = 'auto';
+    changingGroup.timing.fill = 'auto';
     assert_false(inEffect(changingAnimElement), 'Updating Animation fill mode to auto should take effect immediately.');
     assert_true(inEffect(changingGroupElement), 'Updating Timing Group fill mode to auto should take effect immediately.');
   }, 'After phase');

--- a/test/testcases/test-player-cleanup.html
+++ b/test/testcases/test-player-cleanup.html
@@ -67,7 +67,7 @@ timing_test(function() {
 	})
 
 	at(5, function() {
-		player.source.specified.duration = 4;
+		player.source.timing.duration = 4;
 		assert_equals(document.timeline.getCurrentPlayers().length, 1,
 			"Only restarted animation current");
 		assert_equals(_WebAnimationsTestingUtilities._knownPlayers.length, 2,

--- a/test/testcases/test-player.html
+++ b/test/testcases/test-player.html
@@ -610,7 +610,7 @@ timing_test(function() {
       assert_equals(player.currentTime, 4, "currentTime after waiting a while");
 
       // Extend source
-      player.source.specified.duration = 5;
+      player.source.timing.duration = 5;
       assert_equals(player.currentTime, 4, "currentTime after extending source");
       assert_false(player.finished, "Finished state after extending source");
 
@@ -635,7 +635,7 @@ timing_test(function() {
       assert_true(player.finished, "Finished state after ending normally");
 
       // Extend source
-      player.source.specified.duration = 5;
+      player.source.timing.duration = 5;
       assert_equals(player.currentTime, 3.0, "currentTime after extending source");
       assert_false(player.finished, "Finished state after extending source");
 
@@ -656,7 +656,7 @@ timing_test(function() {
     assert_false(player.finished, "Finished state before shortening");
 
     // Shorten source
-    player.source.specified.duration = 1;
+    player.source.timing.duration = 1;
     assert_equals(player.currentTime, 2.0, "currentTime after shortening");
     assert_true(player.finished, "Finished state after shortening");
 
@@ -681,7 +681,7 @@ timing_test(function() {
       assert_false(player.finished, "Finished state before shortening");
 
       // Shorten source
-      player.source.specified.duration = 1;
+      player.source.timing.duration = 1;
       assert_equals(player.currentTime, 1.7, "currentTime after shortening");
       assert_true(player.finished, "Finished state after shortening");
     });
@@ -698,7 +698,7 @@ timing_test(function() {
     assert_false(player.finished, "Finished state before shortening");
 
     // Shorten source
-    player.source.specified.duration = 1;
+    player.source.timing.duration = 1;
     assert_equals(player.currentTime, 2.0, "currentTime after shortening");
     assert_false(player.finished, "Finished state after shortening");
 
@@ -723,7 +723,7 @@ timing_test(function() {
       assert_true(player.finished, "Finished state after waiting");
 
       // "Add" content
-      player.source.specified.duration = 3;
+      player.source.timing.duration = 3;
 
       // We should pick up from 0, not jump 0.2s in
       assert_equals(player.currentTime, 0, "currentTime after extending");

--- a/test/testcases/test-update-state.html
+++ b/test/testcases/test-update-state.html
@@ -62,7 +62,7 @@ timing_test(function() {
   at(1, function() {
     assert_styles(element, {top: '100px'});
 
-    player.source.specified.delay = -1;
+    player.source.timing.delay = -1;
     assert_styles(element, {top: '200px'});
   });
 }, 'Updated style should be visible after change to specified timing');
@@ -76,7 +76,7 @@ timing_test(function() {
   at(2, function() {
     assert_styles(element, {right: '100px'});
 
-    group.children[0].specified.duration = 0.5;
+    group.children[0].timing.duration = 0.5;
     assert_styles(element, {right: '150px'});
 
     group.children[0].remove();
@@ -106,7 +106,7 @@ timing_test(function() {
       group.append(group);
     } catch (e) {
     }
-    player2.source.specified.delay = -1;
+    player2.source.timing.delay = -1;
     assert_styles(element, {bottom: '600px'});
   });
 }, 'Updated style should be visible despite unrelated errors');

--- a/test/testcases/unit-test-clone.html
+++ b/test/testcases/unit-test-clone.html
@@ -29,7 +29,7 @@ var anim = new Animation(elem, animFunc, 1.0);
 var clone = anim.clone();
 test(function() {assert_true(clone instanceof Animation)},
      "Clone should be an Animation");
-test(function() {assert_equals(clone.specified.duration, 1.0)},
+test(function() {assert_equals(clone.timing.duration, 1.0)},
      "Clone should take Timing.duration");
 test(function() {assert_equals(clone.target, elem)},
      "Clone should take target");
@@ -39,7 +39,7 @@ var animationGroup = new AnimationGroup([anim, clone], 4.0);
 var animationGroupClone = animationGroup.clone();
 test(function() {assert_true(animationGroupClone instanceof AnimationGroup, true)},
      "AnimationGroup clone should be a AnimationGroup");
-test(function() {assert_equals(animationGroupClone.specified.duration, 4.0)},
+test(function() {assert_equals(animationGroupClone.timing.duration, 4.0)},
      "AnimationGroup clone should take Timing.duration");
 test(function() {assert_equals(animationGroupClone.children.length, 2)},
      "AnimationGroup clone should clone children");
@@ -57,7 +57,7 @@ var animationSequence = new AnimationSequence([anim, clone], 6.0);
 var animationSequenceClone = animationSequence.clone();
 test(function() {assert_true(animationSequenceClone instanceof AnimationSequence)},
      "AnimationSequence clone should be a AnimationSequence");
-test(function() {assert_equals(animationSequenceClone.specified.duration, 6.0)},
+test(function() {assert_equals(animationSequenceClone.timing.duration, 6.0)},
      "AnimationSequence clone should take Timing.duration");
 test(function() {assert_equals(animationSequenceClone.children.length, 2)},
      "AnimationSequence clone should clone children");

--- a/test/testcases/unit-test-delay.html
+++ b/test/testcases/unit-test-delay.html
@@ -39,12 +39,12 @@ expectDuration(anim1, 3.0, "Animation 1 duration should match specified value");
 expectDuration(anim2, 2.0, "Animation 2 duration should match specified value");
 expectDuration(animationGroup, 3.0,
     "AnimationGroup duration should be max of childrens' end times");
-anim1.specified.delay = 2.0;
+anim1.timing.delay = 2.0;
 expectDuration(anim1, 3.0, "Animation 1 duration should not include delay");
 expectEndTime(anim1, 5.0, "Animation 1 end time should include delay");
 expectDuration(animationGroup, 5.0,
     "AnimationGroup duration should still be max of childrens' end times");
-anim2.specified.endDelay = 4.0;
+anim2.timing.endDelay = 4.0;
 expectDuration(anim2, 2.0, "Animation 2 duration should not include endDelay");
 expectEndTime(anim2, 6.0, "Animation 2 end time should include endDelay");
 expectDuration(animationGroup, 6.0,
@@ -54,10 +54,10 @@ var animationSequence = new AnimationSequence([anim1, anim2]);
 expectDuration(animationSequence, 11.0,
     "AnimationSequence duration should be sum of childrens' total durations");
 expectEndTime(anim2, 11.0, "Animation 2 end time should include Animation 1");
-anim1.specified.delay = 4.0;
+anim1.timing.delay = 4.0;
 expectEndTime(anim2, 13.0,
     "Animation 2 end time should be updated by changes to animation 1 delay");
-anim1.specified.endDelay = 3.0;
+anim1.timing.endDelay = 3.0;
 expectDuration(anim1, 3.0, "Animation 1 duration should not include endDelay");
 expectEndTime(anim1, 10.0, "Animation 1 end time should include endDelay");
 expectEndTime(anim2, 16.0, "Animation 2 end time should include Animation 1 endDelay");

--- a/test/testcases/unit-test-dom-operations.html
+++ b/test/testcases/unit-test-dom-operations.html
@@ -29,7 +29,7 @@ function initGroup() {
 }
 
 function toOrdering(list) {
-  return [].map.call(list, function(animation) { return animation.specified.duration; });
+  return [].map.call(list, function(animation) { return animation.timing.duration; });
 }
 
 function assert_child_order(group, list, message) {

--- a/test/testcases/unit-test-duration.html
+++ b/test/testcases/unit-test-duration.html
@@ -30,7 +30,7 @@ var animationSequence = new AnimationSequence();
 // Animation
 test(function() {assert_equals(anim.duration,  0.0)},
      "Animation duration should use intrinsic value");
-anim.specified.duration = 1.0;
+anim.timing.duration = 1.0;
 test(function() {assert_equals(anim.duration,  1.0)},
      "Animation duration should use specified value");
 // AnimationGroup
@@ -39,7 +39,7 @@ test(function() {assert_equals(animationGroup.duration,  0.0)},
 animationGroup.append(anim);
 test(function() {assert_equals(animationGroup.duration,  3.0)},
      "AnimationGroup duration should be derived from child");
-animationGroup.specified.duration = 2.0;
+animationGroup.timing.duration = 2.0;
 test(function() {assert_equals(animationGroup.duration,  2.0)},
      "AnimationGroup duration should use specified value");
 // AnimationSequence
@@ -48,7 +48,7 @@ test(function() {assert_equals(animationSequence.duration,  0.0)},
 animationSequence.append(anim);
 test(function() {assert_equals(animationSequence.duration,  3.0)},
      "AnimationSequence duration should be derived from child");
-animationSequence.specified.duration = 4.0;
+animationSequence.timing.duration = 4.0;
 test(function() {assert_equals(animationSequence.duration,  4.0)},
      "AnimationSequence duration should use specified value");
 
@@ -59,7 +59,7 @@ test(function() {
   assert_equals(anim.duration,  1.0);
 }, "Animation.duration should be read-only");
 
-anim.specified.duration = 14.0;
+anim.timing.duration = 14.0;
 test(function() {assert_equals(anim.activeDuration,  42.0)},
      "activeDuration should always reflect TimedItem.duration");
 

--- a/test/testcases/unit-test-modify-timing-params.html
+++ b/test/testcases/unit-test-modify-timing-params.html
@@ -34,10 +34,10 @@ test(function() {
   });
   assert_equals(anim.startTime,  0.0);
 }, "startTime should be read-only");
-anim.specified.duration = 3.0;
+anim.timing.duration = 3.0;
 test(function() {assert_equals(anim.endTime,  3.0)},
      "endTime should reflect Timing.duration");
-anim.specified.duration = 4.0;
+anim.timing.duration = 4.0;
 test(function() {assert_equals(anim.endTime,  4.0)},
      "endTime should reflect duration");
 
@@ -50,20 +50,20 @@ test(function() {
 
 // Test that updates to a TimedItem's endTime cause re-layout of a parent
 // parallel group.
-anim.specified.duration = 3;
+anim.timing.duration = 3;
 var animationGroup = new AnimationGroup([anim]);
 test(function() {assert_equals(animationGroup.duration,  3.0)},
      "Parallel group duration should reflect child endTime");
 test(function() {assert_equals(animationGroup.endTime,  3.0)},
      "Parallel group end time should reflect child endTime");
 // Update via Timing.duration
-anim.specified.duration = 8.0;
+anim.timing.duration = 8.0;
 test(function() {assert_equals(animationGroup.duration,  8.0)},
      "Parallel group duration should reflect updated child Timing.duration");
 test(function() {assert_equals(animationGroup.endTime,  8.0)},
      "Parallel group end time should reflect updated child Timing.duration");
 // Update via duration
-anim.specified.duration = 9.0;
+anim.timing.duration = 9.0;
 test(function() {assert_equals(animationGroup.duration,  9.0)},
      "Parallel group duration should reflect updated child duration");
 test(function() {assert_equals(animationGroup.endTime,  9.0)},
@@ -71,7 +71,7 @@ test(function() {assert_equals(animationGroup.endTime,  9.0)},
 
 // Test that updates to a TimedItem's delay and duration cause
 // re-layout of a parent sequence group.
-anim.specified.duration = "auto";
+anim.timing.duration = "auto";
 var siblingAnim = new Animation(document.getElementById("anim"), {top: "100px"},
     1.0);
 var animationSequence = new AnimationSequence([anim, siblingAnim]);
@@ -86,7 +86,7 @@ test(function() {assert_equals(animationSequence.duration,  1.0)},
 test(function() {assert_equals(animationSequence.endTime,  1.0)},
      "Sequence group end time should reflect child durations");
 // delay
-anim.specified.delay = 11.0;
+anim.timing.delay = 11.0;
 test(function() {assert_equals(siblingAnim.startTime,  11.0)},
      "Sequence group should update sibling after updated child delay");
 test(function() {assert_equals(animationSequence.duration,  12.0)},
@@ -94,7 +94,7 @@ test(function() {assert_equals(animationSequence.duration,  12.0)},
 test(function() {assert_equals(animationSequence.endTime,  12.0)},
      "Sequence group end time should reflect updated child delay");
 // duration
-anim.specified.duration = 12.0;
+anim.timing.duration = 12.0;
 test(function() {assert_equals(siblingAnim.startTime,  23.0)},
      "Sequence group should update sibling after updated child Timing.duration");
 test(function() {assert_equals(animationSequence.duration,  24.0)},


### PR DESCRIPTION
TimedItem.specified is now deprecated. It has been replaced by
TimedItem.timing.

Meeting minutes describing this change:
http://lists.w3.org/Archives/Public/public-fx/2014AprJun/0005.html
