### PR TITLE
fix: undefined onfinish event target

### DIFF
--- a/test/testcases/test-player-finish-event.html
+++ b/test/testcases/test-player-finish-event.html
@@ -35,6 +35,7 @@ function assertFinishEvents(description, player, expectedEvents) {
         asyncTestHandle.step(function() {
           assert_equals(event.currentTime, expectedEvent.currentTime, 'event.currentTime');
           assert_equals(event.timelineTime, expectedEvent.timelineTime, 'event.timelineTime');
+          assert_equals(event.target, player, 'event.target');
           assert_approx_equals(document.timeline.currentTime, expectedEvent.timelineTime, 50, 'timeline.currentTime');
         });
         asyncTestHandle.done();

--- a/web-animations.js
+++ b/web-animations.js
@@ -680,7 +680,7 @@ AnimationPlayer.prototype = {
         currentTime: this.currentTime,
         timelineTime: this.timeline.currentTime
       });
-      event._initialize(this.target);
+      event._initialize(this);
       callEventHandlers(this, 'finish', event);
     }
     this._finishedFlag = this.finished;


### PR DESCRIPTION
Hi it's me again

When listening to the onfinish event, the target of the created event is _undefined_.
Is it supposed to be the AnimationPlayer source there ?
