### PR TITLE
Ensure that non-numeric property types work with effectValueAtLocalTime.

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -1643,7 +1643,8 @@ function toUsableValue(property, value) {
       }
       var propertyType = getType(property);
       var internalUnderlying = propertyType.fromCssValue(underlying);
-      return propertyType.toCssValue(value.compositeOnto(property, internalUnderlying));
+      return propertyType.toCssValue(value.compositeOnto(property,
+	  internalUnderlying));
     }
   }   
 }

--- a/web-animations.js
+++ b/web-animations.js
@@ -1641,8 +1641,9 @@ function toUsableValue(property, value) {
       if (underlying == undefined) {
         throw new TypeError('Underlying value undefined');
       }
-      var internalUnderlying = propertyTypes[property].fromCssValue(underlying);
-      return propertyTypes[property].toCssValue(value.compositeOnto(property, internalUnderlying));
+      var propertyType = getType(property);
+      var internalUnderlying = propertyType.fromCssValue(underlying);
+      return propertyType.toCssValue(value.compositeOnto(property, internalUnderlying));
     }
   }   
 }


### PR DESCRIPTION
Non-numeric properties don't have specific entries in the propertyTypes
dictionary. Rather than looking properties up directly, using getType
ensures the generic type entry is used when none other is available.
