### PR TITLE
Explicitly allow PIL to be installed from external sources.

### DIFF
--- a/tools/python/requirements.txt
+++ b/tools/python/requirements.txt
@@ -7,4 +7,6 @@ selenium
 # Requirements for using -x
 pyvirtualdisplay
 pyscreenshot
+--allow-external=PIL
+--allow-unverified=PIL
 PIL

--- a/tools/python/setup.sh
+++ b/tools/python/setup.sh
@@ -29,6 +29,10 @@ EOF
 
   if virtualenv --system-site-packages .; then
     echo -e;
+    (
+      source bin/activate
+      pip install --upgrade pip
+    )
   else
    cat <<EOF
 Was unable to set up the virtualenv environment. Please see output for errors.

--- a/tools/python/setup.sh
+++ b/tools/python/setup.sh
@@ -29,10 +29,6 @@ EOF
 
   if virtualenv --system-site-packages .; then
     echo -e;
-    (
-      source bin/activate
-      pip install --upgrade pip
-    )
   else
    cat <<EOF
 Was unable to set up the virtualenv environment. Please see output for errors.
@@ -43,17 +39,22 @@ fi
 
 source bin/activate
 
-# Check if the dependencies are installed
-pip install --no-download -r requirements.txt > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-  # Install dependencies
-  pip install -r requirements.txt --upgrade
+function ensureRequirementsMet() {
+  # Check if installed
+  pip install --no-download $@ > /dev/null 2>&1
   if [ $? -ne 0 ]; then
-    cat <<EOF
-Unable to install the required dependencies. Please see error output above.
+    # Install dependencies
+    pip install --upgrade $@
+    if [ $? -ne 0 ]; then
+      cat <<EOF
+Unable to install dependencies. Please see error output above.
 EOF
-    exit 1
+      exit 1
+    fi
   fi
-fi
+}
+
+ensureRequirementsMet 'pip>=1.5'
+ensureRequirementsMet -r requirements.txt
 
 cd $OLD_PWD


### PR DESCRIPTION
Fix for #592.
This will automatically upgrade existing virtualenv testing setups to the latest pip.
