### PR TITLE
Make propertyIsSVGAttrib available to test harness.

### DIFF
--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -145,22 +145,6 @@ function instrument(src) {
   var inst = window.__resources__[src] = new Instrumenter().instrumentSync(js, src);
 }
 
-
-var svg_properties = {
-  cx: 1,
-  cy: 1,
-  height: 1,
-  r: 1,
-  width: 1,
-  x: 1,
-  y: 1
-};
-
-var is_svg_attrib = function(property, target) {
-  return target.namespaceURI == 'http://www.w3.org/2000/svg' &&
-      property in svg_properties;
-};
-
 var svg_namespace_uri = 'http://www.w3.org/2000/svg';
 
 /**
@@ -342,7 +326,7 @@ function _assert_style_element(object, style, description) {
 
       var output_prop_name = _WebAnimationsTestingUtilities._prefixProperty(prop_name);
 
-      var is_svg = is_svg_attrib(prop_name, object);
+      var is_svg = _WebAnimationsTestingUtilities._propertyIsSVGAttrib(prop_name, object);
       if (is_svg) {
         reference_element.setAttribute(prop_name, prop_value);
 

--- a/test/test-generator.html
+++ b/test/test-generator.html
@@ -39,6 +39,7 @@ input#iframeSrc {
 <div> Outputted Checks </div>
 <pre id = "checks"></pre>
 
+<script src="../web-animations.js"></script>
 <script>
 "use strict";
 
@@ -167,21 +168,6 @@ function findElementsToCheck(rawString){
   }
 }
 
-var svgProperties = {
-  'cx': 1,
-  'cy': 1,
-  'height': 1,
-  'r': 1,
-  'width': 1,
-  'x': 1,
-  'y': 1,
-};
-
-var propertyIsSVGAttrib = function(property, target) {
-  return target.namespaceURI == 'http://www.w3.org/2000/svg' &&
-      property in svgProperties;
-};
-
 function generate(time){
   console.log("Generating checks for t=", time);
 
@@ -193,7 +179,7 @@ function generate(time){
       var propsPrint = "{";
       for (var j in checks[x].properties){
         var p = checks[x].properties[j];
-        var isSVG = propertyIsSVGAttrib(p, checks[x].object[i]);
+        var isSVG = _WebAnimationsTestingUtilities._propertyIsSVGAttrib(p, checks[x].object[i]);
 
         if(isSVG) var props = checks[x].object[i].attributes;
         else var props = checks[x].object[i].currentStyle ||

--- a/web-animations.js
+++ b/web-animations.js
@@ -5594,7 +5594,8 @@ window._WebAnimationsTestingUtilities = {
   _types: propertyTypes,
   _knownPlayers: PLAYERS,
   _pacedTimingFunction: PacedTimingFunction,
-  _prefixProperty: prefixProperty
+  _prefixProperty: prefixProperty,
+  _propertyIsSVGAttrib: propertyIsSVGAttrib
 };
 
 defineDeprecatedProperty(window, 'Timeline', function() {


### PR DESCRIPTION
We were previously specifying the list of SVG attributes in 3 files. Now we only need to specify the list once.
