### PR TITLE
SVG transforms now complete when fill=none

### DIFF
--- a/test/testcases.js
+++ b/test/testcases.js
@@ -42,6 +42,7 @@ var tests = [
   'auto-test-svg-anim.html',
   'auto-test-svg-circle.html',
   'auto-test-svg-color.html',
+  'auto-test-svg-transform.html',
   'auto-test-text-shadow.html',
   'auto-test-timing-functions.html',
   'auto-test-to-animation.html',

--- a/test/testcases/auto-test-svg-transform-checks.js
+++ b/test/testcases/auto-test-svg-transform-checks.js
@@ -1,0 +1,23 @@
+timing_test(function() {
+  at(0 * 1000, function() {
+    assert_styles(".anim",{'transform':'scale(1)'});
+  });
+  at(0.2 * 1000, function() {
+    assert_styles(".anim",{'transform':'scale(2)'});
+  });
+  at(0.4 * 1000, function() {
+    assert_styles(".anim",{'transform':'scale(3)'});
+  });
+  at(0.6000000000000001 * 1000, function() {
+    assert_styles(".anim",{'transform':'scale(4)'});
+  });
+  at(0.8 * 1000, function() {
+    assert_styles(".anim",{'transform':'scale(5)'});
+  });
+  at(1 * 1000, function() {
+    assert_styles(".anim",{'transform':'null'});
+  });
+  at(1.2 * 1000, function() {
+    assert_styles(".anim",{'transform':'null'});
+  });
+}, "Auto generated tests");

--- a/test/testcases/auto-test-svg-transform.html
+++ b/test/testcases/auto-test-svg-transform.html
@@ -1,0 +1,39 @@
+<!--
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html><meta charset="UTF-8">
+<style>
+.anim {
+  fill: lightsteelblue;
+}
+
+.expectation {
+  fill: red;
+}
+</style>
+<svg width="600px" height="200px">
+  <rect class="expectation" x="190px" y="60px" width="120px" height="120px">
+  </rect>
+  <rect class="anim" x="10px" y="10px" width="20px" height="20px"></rect>
+</svg>
+<script src="../bootstrap.js"></script>
+<script>
+"use strict";
+var rect = document.querySelector(".anim")
+
+document.timeline.play(new Animation(rect, [{transform: "scale(1)"}, {transform: "scale(6)"}], {duration: 1 * 1000, fill: 'none'}));
+
+</script>

--- a/web-animations.js
+++ b/web-animations.js
@@ -4653,6 +4653,7 @@ var svgProperties = {
   'r': 1,
   'stopColor': 1,
   'stroke': 1,
+  'transform': 1,
   'width': 1,
   'x': 1,
   'y': 1


### PR DESCRIPTION
The transforms previously remained in effect, as if the page author had
requested fill=forwards

https://github.com/web-animations/web-animations-js/issues/605
