### PR TITLE
File bug against Firefox 31 getTotalLength() and update failure expectations

### DIFF
--- a/test/testcases/auto-test-path.html
+++ b/test/testcases/auto-test-path.html
@@ -107,6 +107,14 @@ var expected_failures = [
     ],
     message: 'Doesn\'t quite follow path correctly.',
   }, {
+    browser_configurations: [{ firefox: true, version: '31' }],
+    tests: [
+      '#anim2',
+      '#anim3',
+      '#anim4 at t=(1|2|7|11)000ms',
+    ],
+    message: 'SVGPath.getTotalLength() broken in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1024926',
+  }, {
     browser_configurations: [{ msie: true }],
     tests: [
       '#anim2 at t=(0|(1|2|3|4|9|10|11)000)ms',

--- a/test/testcases/impl-test-paced-timing-function.html
+++ b/test/testcases/impl-test-paced-timing-function.html
@@ -25,6 +25,12 @@ limitations under the License.
 <script>
 "use strict";
 
+var expected_failures = [{
+  browser_configurations: [{ firefox: true, version: '31' }],
+  tests: ['range between bounds'],
+  message: 'MotionPathEffect broken in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1024926',
+}];
+
 var PacedTimingFunction = _WebAnimationsTestingUtilities._pacedTimingFunction;
 
 var effect =


### PR DESCRIPTION
SVGPath.getTotalLength() cache invalidation broken in Firefox 31.
https://bugzilla.mozilla.org/show_bug.cgi?id=1024926
