### PR TITLE
Allow Travis Android failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
 # Disabled until travis-ci/travis-ci#1696 is fixed.
 #  fast_finish: true
   allow_failures:
+    - env: BROWSER=Android-Chrome ARGS=''
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=INTERNETEXPLORER --remote-caps=version=10 --remote-caps=platform="Windows 8"'
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=SAFARI --remote-caps=version=6 --remote-caps=platform="OS X 10.8"'
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=IPHONE --remote-caps=version=6 --remote-caps=platform="OS X 10.8"'


### PR DESCRIPTION
Maintaining Android on Travis has been less beneficial than it has been costly maintenance wise.
With development moving to web-animations-next there is little reason to expend further maintenance time on Android Travis in this polyfill.
