### PR TITLE
Update EffectCallback parameters to match spec

### DIFF
--- a/test/testcases/auto-test-iterations-fill.html
+++ b/test/testcases/auto-test-iterations-fill.html
@@ -138,8 +138,8 @@ for (var i = 0; i < directions.length; i++) {
   }));
 }
 
-function sampleFunc(timeFraction, animation) {
-  animation.target.innerHTML = Math.floor(timeFraction * 1000) / 1000 + " : " + animation.currentIteration;
+function sampleFunc(timeFraction, target, animation) {
+  target.innerHTML = Math.floor(timeFraction * 1000) / 1000 + " : " + animation.currentIteration;
 }
 
 for (var i = 0; i < fills.length; i++) {

--- a/web-animations.js
+++ b/web-animations.js
@@ -1331,7 +1331,6 @@ var Animation = function(target, animationEffect, timingInput) {
   } finally {
     exitModifyCurrentAnimationState(null);
   }
-  this._previousTimeFraction = null;
 };
 
 Animation.prototype = createObject(TimedItem.prototype, {
@@ -1342,8 +1341,7 @@ Animation.prototype = createObject(TimedItem.prototype, {
     if (isDefinedAndNotNull(this.effect) &&
         !(this.target instanceof PseudoElementReference)) {
       if (isEffectCallback(this.effect)) {
-        this.effect(this._timeFraction, this, this._previousTimeFraction);
-        this._previousTimeFraction = this._timeFraction;
+        this.effect(this._timeFraction, this.target, this);
       } else {
         this.effect._sample(this._timeFraction, this.currentIteration,
             this.target, this.underlyingValue);


### PR DESCRIPTION
#614

The parameters passed to custom effect callbacks should be:
`callback EffectCallback = void (double? timeFraction, Animatable currentTarget, Animation animation);`
Spec: http://dev.w3.org/fxtf/web-animations/#idl-def-EffectCallback
