### PR TITLE
[RFC] Decompose matrices individually to allow rotate(0deg) -> rotate(360deg) after a matrix

### DIFF
--- a/test/testcases/auto-test-composite-transforms-matrix-rotate.html
+++ b/test/testcases/auto-test-composite-transforms-matrix-rotate.html
@@ -49,11 +49,11 @@ limitations under the License.
 
 </style>
 
-<div>Right edge of each box should align with black line at end of test.</div>
+<div>The first two divs should rotate 360 degrees.</div>
 <div id="a" class="anim"></div>
 <div id="a" style="top: 50px; left: 200px;" class="expected"></div>
 <div id="b" class="anim"></div>
-<div id="b" style="top: 150px; left: 0px;" class="expected"></div>
+<div id="b" style="top: 150px; left: 100px;" class="expected"></div>
 <div id="c" class="anim"></div>
 <div id="c" style="top: 250px; left: 200px;" class="expected"></div>
 <div id="d" class="anim"></div>
@@ -84,12 +84,21 @@ dt.play(new Animation(divs[0], [
   {transform: "matrix(1,0,0,1,0,0) rotate(0deg)"},
   {transform: "matrix(1,0,0,1,200,0) rotate(360deg)"},
 ], timing));
-dt.play(new Animation(divs[1],
-    [{transform: "rotate(0deg)"}, {transform: "rotate(90deg)"}], timing));
+
+dt.play(new Animation(divs[1], [
+  {transform: "matrix(1,0,0,1,0,0)"},
+  {transform: "matrix(1,0,0,1,100,0)"},
+], timing));
+dt.play(new Animation(divs[1], new KeyframeEffect([
+  {transform: "rotate(0deg)"},
+  {transform: "rotate(360deg)"},
+], "add"), timing));
+
 dt.play(new Animation(divs[2], [
   {transform: "translate(0px, 0px) rotate(0deg)"},
   {transform: "translate(200px, 0px) rotate(90deg)"},
 ], timing));
+
 dt.play(new Animation(divs[3], [
   {transform: "rotate(0deg) translate(0px, 0px)"},
   {transform: "rotate(90deg) translate(200px, 0px)"},

--- a/test/testcases/auto-test-composite-transforms-matrix-rotate.html
+++ b/test/testcases/auto-test-composite-transforms-matrix-rotate.html
@@ -1,0 +1,98 @@
+<!--
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html><meta charset="UTF-8">
+<style>
+.anim {
+  left: 0px;
+  width: 100px;
+  height: 100px;
+  background-color: #FAA;
+  position: absolute;
+}
+
+.expected {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  border-right: 1px solid black;
+}
+
+#a {
+  top: 50px
+}
+
+#b {
+  top: 150px;
+}
+
+#c {
+  top: 250px;
+}
+
+#d {
+  top: 350px;
+}
+
+</style>
+
+<div>Right edge of each box should align with black line at end of test.</div>
+<div id="a" class="anim"></div>
+<div id="a" style="top: 50px; left: 200px;" class="expected"></div>
+<div id="b" class="anim"></div>
+<div id="b" style="top: 150px; left: 0px;" class="expected"></div>
+<div id="c" class="anim"></div>
+<div id="c" style="top: 250px; left: 200px;" class="expected"></div>
+<div id="d" class="anim"></div>
+<div id="d" style="top: 550px; left: 0px;" class="expected"></div>
+
+<div style="height: 700px;"></div>
+
+<script>
+var expected_failures = [
+  {
+    browser_configurations: [{ msie: true }],
+    tests: ['Auto generated tests at t=2000ms'],
+    message: 'Floating point issues.',
+  }
+];
+</script>
+<script src="../bootstrap.js"></script>
+<script>
+"use strict";
+
+var divs = document.querySelectorAll(".anim");
+
+var dt = document.timeline;
+
+var timing = {duration: 2 * 1000, fill: 'forwards'};
+
+dt.play(new Animation(divs[0], [
+  {transform: "matrix(1,0,0,1,0,0) rotate(0deg)"},
+  {transform: "matrix(1,0,0,1,200,0) rotate(360deg)"},
+], timing));
+dt.play(new Animation(divs[1],
+    [{transform: "rotate(0deg)"}, {transform: "rotate(90deg)"}], timing));
+dt.play(new Animation(divs[2], [
+  {transform: "translate(0px, 0px) rotate(0deg)"},
+  {transform: "translate(200px, 0px) rotate(90deg)"},
+], timing));
+dt.play(new Animation(divs[3], [
+  {transform: "rotate(0deg) translate(0px, 0px)"},
+  {transform: "rotate(90deg) translate(200px, 0px)"},
+], timing));
+
+</script>

--- a/web-animations.js
+++ b/web-animations.js
@@ -4411,11 +4411,17 @@ var transformType = {
     var out = [];
     for (var i = 0; i < Math.min(from.length, to.length); i++) {
       if (from[i].t !== to[i].t || isMatrix(from[i])) {
-        break;
+        var fromDecomposed = decomposeMatrix(convertToMatrix([from[i]]));
+        var toDecomposed = decomposeMatrix(convertToMatrix([to[i]]));
+        out.push(interpolateDecomposedTransformsWithMatrices(
+            fromDecomposed, toDecomposed, f));
+      } else {
+        out.push(interpTransformValue(from[i], to[i], f));
       }
-      out.push(interpTransformValue(from[i], to[i], f));
     }
 
+    /*
+    // Decomposing all later rules would break interpolation of rotate(0deg) to rotate(360deg)
     if (i < Math.min(from.length, to.length) ||
         from.some(isMatrix) || to.some(isMatrix)) {
       if (from.decompositionPair !== to) {
@@ -4426,10 +4432,9 @@ var transformType = {
         to.decompositionPair = from;
         to.decomposition = decomposeMatrix(convertToMatrix(to.slice(i)));
       }
-      out.push(interpolateDecomposedTransformsWithMatrices(
-          from.decomposition, to.decomposition, f));
       return out;
     }
+    */
 
     for (; i < from.length; i++) {
       out.push(interpTransformValue(from[i], {t: null, d: null}, f));


### PR DESCRIPTION
Currently in `transformType.interpolate()` the presence of a matrix forces itself and _all later transforms_ to be decomposed into their components for interpolation.  But decomposing `rotate(0deg)` and `rotate(360deg)` into matrices breaks the interpolation of the angle value.  (Because both of those rotations decompose to a rotation of 0!)

This patch attempts to fix this: when a matrix (or incompatible types) are encountered, we only perform decomposition at that stage of the composition.  Later interpolations can be performed without decomposition into matrices.

I added a test case `auto-test-composite-transforms-matrix-rotate.html` (a slight modification of `
auto-test-composite-transforms.html`).

```
dt.play(new Animation(divs[0], [
  {transform: "matrix(1,0,0,1,0,0) rotate(0deg)"},
  {transform: "matrix(1,0,0,1,200,0) rotate(360deg)"},
], timing));
```

With the old behaviour the first two divs do not rotate at all.  With the new behaviour you will see them perform a full rotation.

Concerns:
- It looks like `from.decompositionPair = to;` and `from.decomposition` were assigned as a way of caching the decomposed matrix, but I did not reproduce caching in this patch.

Alternatives:
- I thought a workaround might be to specify additional keyframes with intermediate angles, e.g. `0deg`, `120deg`, `240deg` and `360deg` but the decomposition still causes 240 to rotate anti-clockwise to "360" (because it was decomposed to 0).
