### PR TITLE
[RFC] Interpolate paired matrices, avoid decomposing rest of chain

### DIFF
--- a/test/testcases.js
+++ b/test/testcases.js
@@ -6,6 +6,7 @@ var tests = [
   'auto-test-color.html',
   'auto-test-color-names.html',
   'auto-test-composite-transforms.html',
+  'auto-test-composite-transforms-matrix-rotate.html',
   'auto-test-compositor.html',
   'auto-test-delay.html',
   'auto-test-element-animate.html',

--- a/test/testcases/auto-test-composite-transforms-matrix-rotate-checks.js
+++ b/test/testcases/auto-test-composite-transforms-matrix-rotate-checks.js
@@ -1,0 +1,46 @@
+timing_test(function() {
+  at(0 * 1000, function() {
+    assert_styles(".anim",{'transform':'matrix(1, 0, 0, 1, 0, 0)'});
+  });
+  at(0.4 * 1000, function() {
+    assert_styles(".anim", [
+      {'transform':'matrix(0.3090, 0.9511, -0.9511, 0.3090, 40, 0)'},
+      {'transform':'matrix(0.3090, 0.9511, -0.9511, 0.3090, 20, 0)'},
+      {'transform':'matrix(1, 0, 0, 1, 40, 0)'},
+      {'transform':'matrix(0.3090, 0.9511, -0.9511, 0.309, 20, 0)'},
+    ]);
+  });
+  at(0.8 * 1000, function() {
+    assert_styles(".anim", [
+      {'transform':'matrix(-0.8090, 0.5878, -0.5878, -0.8090, 80, 0)'},
+      {'transform':'matrix(-0.8090, 0.5878, -0.5878, -0.8090, 40, 0)'},
+      {'transform':'matrix(1, 0, 0, 1, 80, 0)'},
+      {'transform':'matrix(-0.8090, 0.5878, -0.5878, -0.8090, 40, 0)'},
+    ]);
+  });
+  at(1.2000000000000002 * 1000, function() {
+    assert_styles(".anim", [
+      {'transform':'matrix(-0.8090, -0.5878, 0.5878, -0.8090, 120, 0)'},
+      {'transform':'matrix(-0.8090, -0.5878, 0.5878, -0.8090, 60, 0)'},
+      {'transform':'matrix(1, 0, 0, 1, 120, 0)'},
+      {'transform':'matrix(-0.8090, -0.5878, 0.5878, -0.8090, 60, 0)'},
+    ]);
+  });
+  at(1.6 * 1000, function() {
+    assert_styles(".anim", [
+      {'transform':'matrix(0.3090, -0.9511, 0.9511, 0.3090, 160, 0)'},
+      {'transform':'matrix(0.3090, -0.9511, 0.9511, 0.3090, 80, 0)'},
+      {'transform':'matrix(1, 0, 0, 1, 160, 0)'},
+      {'transform':'matrix(0.3090, -0.9511, 0.9511, 0.3090, 80, 0)'},
+    ]);
+  });
+  at(2 * 1000, function() {
+    assert_styles(".anim", [
+      {'transform':'matrix(1, 0, 0, 1, 200, 0)'},
+      {'transform':'matrix(1, 0, 0, 1, 100, 0)'},
+      {'transform':'matrix(1, 0, 0, 1, 200, 0)'},
+      {'transform':'matrix(1, 0, 0, 1, 100, 0)'},
+    ]);
+  });
+}, "Auto generated tests");
+

--- a/test/testcases/auto-test-composite-transforms-matrix-rotate.html
+++ b/test/testcases/auto-test-composite-transforms-matrix-rotate.html
@@ -49,7 +49,7 @@ limitations under the License.
 
 </style>
 
-<div>The first two divs should rotate 360 degrees.</div>
+<div>All the squares should rotate 360 degrees except for the third one (since mismatched types cause fallback to matrix decomposition for the rest of the transform chain).</div>
 <div id="a" class="anim"></div>
 <div id="a" style="top: 50px; left: 200px;" class="expected"></div>
 <div id="b" class="anim"></div>
@@ -57,7 +57,7 @@ limitations under the License.
 <div id="c" class="anim"></div>
 <div id="c" style="top: 250px; left: 200px;" class="expected"></div>
 <div id="d" class="anim"></div>
-<div id="d" style="top: 550px; left: 0px;" class="expected"></div>
+<div id="d" style="top: 350px; left: 100px;" class="expected"></div>
 
 <div style="height: 700px;"></div>
 
@@ -95,13 +95,17 @@ dt.play(new Animation(divs[1], new KeyframeEffect([
 ], "add"), timing));
 
 dt.play(new Animation(divs[2], [
-  {transform: "translate(0px, 0px) rotate(0deg)"},
-  {transform: "translate(200px, 0px) rotate(90deg)"},
+  {transform: "scale(1) rotate(0deg)"},
+  {transform: "matrix(1,0,0,1,200,0) rotate(360deg)"},
 ], timing));
 
 dt.play(new Animation(divs[3], [
-  {transform: "rotate(0deg) translate(0px, 0px)"},
-  {transform: "rotate(90deg) translate(200px, 0px)"},
+  {transform: "scale(1)"},
+  {transform: "matrix(1,0,0,1,100,0)"},
 ], timing));
+dt.play(new Animation(divs[3], new KeyframeEffect([
+  {transform: "rotate(0deg)"},
+  {transform: "rotate(360deg)"},
+], "add"), timing));
 
 </script>

--- a/test/testcases/auto-test-composite-transforms-matrix-rotate.html
+++ b/test/testcases/auto-test-composite-transforms-matrix-rotate.html
@@ -49,11 +49,11 @@ limitations under the License.
 
 </style>
 
-<div>Right edge of each box should align with black line at end of test.</div>
+<div>The first two divs should rotate 360 degrees.</div>
 <div id="a" class="anim"></div>
 <div id="a" style="top: 50px; left: 200px;" class="expected"></div>
 <div id="b" class="anim"></div>
-<div id="b" style="top: 150px; left: 0px;" class="expected"></div>
+<div id="b" style="top: 150px; left: 100px;" class="expected"></div>
 <div id="c" class="anim"></div>
 <div id="c" style="top: 250px; left: 200px;" class="expected"></div>
 <div id="d" class="anim"></div>
@@ -84,12 +84,21 @@ dt.play(new Animation(divs[0], [
   {transform: "matrix(1,0,0,1,0,0) rotate(0deg)"},
   {transform: "matrix(1,0,0,1,200,0) rotate(360deg)"},
 ], timing));
-dt.play(new Animation(divs[1],
-    [{transform: "rotate(0deg)"}, {transform: "rotate(90deg)"}], timing));
+
+dt.play(new Animation(divs[1], [
+  {transform: "matrix(1,0,0,1,0,0)"},
+  {transform: "matrix(1,0,0,1,100,0)"},
+], timing));
+dt.play(new Animation(divs[1], new KeyframeEffect([
+  {transform: "rotate(0deg)"},
+  {transform: "rotate(360deg)"},
+], "add"), timing));
+
 dt.play(new Animation(divs[2], [
   {transform: "translate(0px, 0px) rotate(0deg)"},
   {transform: "translate(200px, 0px) rotate(90deg)"},
 ], timing));
+
 dt.play(new Animation(divs[3], [
   {transform: "rotate(0deg) translate(0px, 0px)"},
   {transform: "rotate(90deg) translate(200px, 0px)"},

--- a/test/testcases/auto-test-composite-transforms-matrix-rotate.html
+++ b/test/testcases/auto-test-composite-transforms-matrix-rotate.html
@@ -1,0 +1,98 @@
+<!--
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html><meta charset="UTF-8">
+<style>
+.anim {
+  left: 0px;
+  width: 100px;
+  height: 100px;
+  background-color: #FAA;
+  position: absolute;
+}
+
+.expected {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  border-right: 1px solid black;
+}
+
+#a {
+  top: 50px
+}
+
+#b {
+  top: 150px;
+}
+
+#c {
+  top: 250px;
+}
+
+#d {
+  top: 350px;
+}
+
+</style>
+
+<div>Right edge of each box should align with black line at end of test.</div>
+<div id="a" class="anim"></div>
+<div id="a" style="top: 50px; left: 200px;" class="expected"></div>
+<div id="b" class="anim"></div>
+<div id="b" style="top: 150px; left: 0px;" class="expected"></div>
+<div id="c" class="anim"></div>
+<div id="c" style="top: 250px; left: 200px;" class="expected"></div>
+<div id="d" class="anim"></div>
+<div id="d" style="top: 550px; left: 0px;" class="expected"></div>
+
+<div style="height: 700px;"></div>
+
+<script>
+var expected_failures = [
+  {
+    browser_configurations: [{ msie: true }],
+    tests: ['Auto generated tests at t=2000ms'],
+    message: 'Floating point issues.',
+  }
+];
+</script>
+<script src="../bootstrap.js"></script>
+<script>
+"use strict";
+
+var divs = document.querySelectorAll(".anim");
+
+var dt = document.timeline;
+
+var timing = {duration: 2 * 1000, fill: 'forwards'};
+
+dt.play(new Animation(divs[0], [
+  {transform: "matrix(1,0,0,1,0,0) rotate(0deg)"},
+  {transform: "matrix(1,0,0,1,200,0) rotate(360deg)"},
+], timing));
+dt.play(new Animation(divs[1],
+    [{transform: "rotate(0deg)"}, {transform: "rotate(90deg)"}], timing));
+dt.play(new Animation(divs[2], [
+  {transform: "translate(0px, 0px) rotate(0deg)"},
+  {transform: "translate(200px, 0px) rotate(90deg)"},
+], timing));
+dt.play(new Animation(divs[3], [
+  {transform: "rotate(0deg) translate(0px, 0px)"},
+  {transform: "rotate(90deg) translate(200px, 0px)"},
+], timing));
+
+</script>

--- a/web-animations.js
+++ b/web-animations.js
@@ -4410,10 +4410,16 @@ var transformType = {
   interpolate: function(from, to, f) {
     var out = [];
     for (var i = 0; i < Math.min(from.length, to.length); i++) {
-      if (from[i].t !== to[i].t || isMatrix(from[i])) {
+      if (isMatrix(from[i]) && isMatrix(to[i])) {
+        var fromDecomposed = decomposeMatrix(convertToMatrix([from[i]]));
+        var toDecomposed = decomposeMatrix(convertToMatrix([to[i]]));
+        out.push(interpolateDecomposedTransformsWithMatrices(
+            fromDecomposed, toDecomposed, f));
+      } else if (from[i].t !== to[i].t) {
         break;
+      } else {
+        out.push(interpTransformValue(from[i], to[i], f));
       }
-      out.push(interpTransformValue(from[i], to[i], f));
     }
 
     if (i < Math.min(from.length, to.length) ||


### PR DESCRIPTION
This is the update for https://github.com/web-animations/web-animations-js/pull/618 since shans pointed out the issues with the former.

Prior to the patch, none of the following rotations were visible.  (Because the rotations were decomposed, which makes the start and end angles, 0 and 360, look the same, which makes interpolation go nowhere!)

With the patch applied, all of the following rotations become visible.  (In Chrome 34, after the patch, all the divs were rotating except for the third.)

```
dt.play(new Animation(divs[0], [
  {transform: "matrix(1,0,0,1,0,0) rotate(0deg)"},
  {transform: "matrix(1,0,0,1,200,0) rotate(360deg)"},
], timing));

dt.play(new Animation(divs[1], [
  {transform: "matrix(1,0,0,1,0,0)"},
  {transform: "matrix(1,0,0,1,100,0)"},
], timing));
dt.play(new Animation(divs[1], new KeyframeEffect([
  {transform: "rotate(0deg)"},
  {transform: "rotate(360deg)"},
], "add"), timing));

dt.play(new Animation(divs[2], [
  {transform: "scale(1) rotate(0deg)"},
  {transform: "matrix(1,0,0,1,200,0) rotate(360deg)"},
], timing));

dt.play(new Animation(divs[3], [
  {transform: "scale(1)"},
  {transform: "matrix(1,0,0,1,100,0)"},
], timing));
dt.play(new Animation(divs[3], new KeyframeEffect([
  {transform: "rotate(0deg)"},
  {transform: "rotate(360deg)"},
], "add"), timing));
```

I put caching in [another branch](https://github.com/joeytwiddle/web-animations-js/tree/decompose-matrices-individually-2-with-caching) because it wasn't very pretty.
