### PR TITLE
Remove test failure expectation for Firefox 31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=SAFARI --remote-caps=version=6 --remote-caps=platform="OS X 10.8"'
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=IPHONE --remote-caps=version=6 --remote-caps=platform="OS X 10.8"'
     - env: BROWSER=Remote ARGS='--verbose -b Remote --sauce --remote-caps=ANDROID --remote-caps=version=4.0 --remote-caps=platform=Linux'
+    # Firefox Aurora PPA has stopped updating as of 2014-06-09, sent email to ubuntu-mozilla-daily@lists.launchpad.net regarding issue.
+    - env: BROWSER=Firefox-aurora ARGS='-x -b Firefox -u'
 
 notifications:
   irc: "irc.freenode.org#webanimations"

--- a/test/testcases/auto-test-path.html
+++ b/test/testcases/auto-test-path.html
@@ -91,14 +91,6 @@ var expected_failures = [
     ],
     message: 'Doesn\'t quite follow path correctly.',
   }, {
-    browser_configurations: [{ firefox: true, version: '31' }],
-    tests: [
-      '#animTR',
-      '#animBL',
-      '#animBR at t=(1|2|7|11)000ms',
-    ],
-    message: 'SVGPath.getTotalLength() broken in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1024926',
-  }, {
     browser_configurations: [{ msie: true }],
     tests: [
       '#animTR at t=(0|(1|2|3|4|9|10|11)000)ms',

--- a/test/testcases/impl-test-paced-timing-function.html
+++ b/test/testcases/impl-test-paced-timing-function.html
@@ -25,12 +25,6 @@ limitations under the License.
 <script>
 "use strict";
 
-var expected_failures = [{
-  browser_configurations: [{ firefox: true, version: '31' }],
-  tests: ['range between bounds'],
-  message: 'MotionPathEffect broken in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1024926',
-}];
-
 var PacedTimingFunction = _WebAnimationsTestingUtilities._pacedTimingFunction;
 
 var effect =


### PR DESCRIPTION
Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=1024926 has now been fixed and pushed to Beta.
Failure expectations can now be removed.
Firefox Aurora is not keeping track with Firefox Beta version + 1 and still contains the bug. Disabled Firefox Aurora channel from turning the tree red and sent an email to the maintainers of the firefox-aurora repository: https://launchpad.net/~ubuntu-mozilla-daily/+archive/ubuntu/firefox-aurora
