### PR TITLE
Add ability to freeze timeline clock for testing

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -288,6 +288,16 @@ AnimationTimeline.prototype = {
       player.pause();
       player.currentTime = pauseAt;
     });
+  },
+  _freezeClockForTesting: function(pauseAt) {
+    delete this.currentTime;
+    Object.defineProperty(this, 'currentTime', {
+      configurable: true,
+      enumerable: true,
+      get: function() {
+        return pauseAt;
+      }
+    });
   }
 };
 


### PR DESCRIPTION
Players may have non-zero start time, and/or playback rates other than
one. As noted in https://github.com/web-animations/web-animations-js/issues/628, calling document.timeline._pauseAnimationsForTesting 
with the current timeline time will change such players' currentTime, and
will change the animated elements' computed style.

We implement a new testing method _freezeClockForTesting that avoids
changing any of the players, it simply freezes the timeline's
currentTime to the supplied time.
